### PR TITLE
bug(vite.config.ts): Vite 설정 경로 별칭 지원 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,15 @@
 		"@types/react-dom": "^19.0.4",
 		"@vitejs/plugin-react": "^4.3.4",
 		"eslint": "^9.21.0",
+		"eslint-config-prettier": "^10.0.2",
+		"eslint-plugin-prettier": "^5.2.3",
 		"eslint-plugin-react-hooks": "^5.1.0",
 		"eslint-plugin-react-refresh": "^0.4.19",
 		"globals": "^15.15.0",
-		"typescript": "~5.7.2",
+		"prettier": "^3.5.3",
+		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.24.1",
-		"eslint-config-prettier": "^10.0.2",
-		"eslint-plugin-prettier": "^5.2.3",
-		"prettier": "^3.5.2",
-		"vite": "^6.2.0"
+		"vite": "^6.2.0",
+		"vite-tsconfig-paths": "^5.1.4"
 	}
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
-	plugins: [react()],
+	plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
## 🚀 반영 브랜치

`bug/#12_vite_경로사용` → `dev`
<br/>

## ✅ 작업 내용

- tsconfig.app.json 파일에 정의된 경로 별칭을 Vite에서도 사용할 수 있도록 해주는 플러그인 가져오기
- `npm install -D vite-tsconfig-paths` 설치
<br/>

## 📌 이슈 링크
- #12 
