### PR TITLE
feat(login): 로그인 및 가입 페이지 UI 구현

### DIFF
--- a/src/components/AccountPage/FindId.tsx
+++ b/src/components/AccountPage/FindId.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Typography,
+  TextField,
+  Box,
+} from '@mui/material';
+
+const FindId = (): React.JSX.Element => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [userId, setUserId] = useState('');
+  const [showResult, setShowResult] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    try {
+      console.log('아이디 찾기 요청:', { name, email, phone });
+      setUserId('synergy2025'); // 테스트용 ID
+      setShowResult(true);
+    } catch (error) {
+      console.error('아이디 찾기 에러:', error);
+      alert('아이디 찾기 중 오류가 발생했습니다.');
+    }
+  };
+
+  const resetForm = (): void => {
+    setName('');
+    setEmail('');
+    setPhone('');
+    setUserId('');
+    setShowResult(false);
+  };
+
+  if (showResult) {
+    return (
+      <Box sx={{ width: '300px', margin: '20px auto', textAlign: 'center' }}>
+        <Typography variant="h1" sx={{ fontSize: '28px', marginBottom: '10px' }}>
+          F'LINK
+        </Typography>
+        <Typography variant="h2" sx={{ fontSize: '20px', marginBottom: '30px' }}>
+          아이디 찾기
+        </Typography>
+        <Typography sx={{ fontSize: '16px', marginBottom: '20px' }}>
+          회원님의 아이디는 <strong>{userId}</strong> 입니다.
+        </Typography>
+        <Button
+          variant="contained"
+          onClick={resetForm}
+          sx={{
+            width: '100%',
+            marginTop: '20px',
+          }}
+        >
+          확인
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ width: '300px', margin: '20px auto', textAlign: 'center' }}>
+      <Typography variant="h1" sx={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '10px' }}>
+        F'LINK
+      </Typography>
+      <Typography variant="h2" sx={{ fontSize: '24px', marginBottom: '30px' }}>
+        아이디 찾기
+      </Typography>
+      <form onSubmit={handleSubmit}>
+        <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+          <TextField
+            fullWidth
+            id="name"
+            label="성함"
+            placeholder="성함을 입력하세요."
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </Box>
+
+        <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+          <TextField
+            fullWidth
+            id="email"
+            label="이메일"
+            type="email"
+            placeholder="example@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </Box>
+
+        <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+          <TextField
+            fullWidth
+            id="phone"
+            label="휴대폰 번호"
+            placeholder="010-0000-0000"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+          />
+        </Box>
+
+        <Button
+          type="submit"
+          variant="contained"
+          sx={{
+            width: '100%',
+            backgroundColor: '#ddd',
+          }}
+        >
+          확인
+        </Button>
+      </form>
+    </Box>
+  );
+};
+
+export default FindId;

--- a/src/components/AccountPage/ResetPassword.tsx
+++ b/src/components/AccountPage/ResetPassword.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { Box, Typography, TextField, Button } from '@mui/material';
+
+const ResetPassword = (): React.JSX.Element => {
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      console.log('비밀번호 재설정 요청:', { name, email, phone });
+      // TODO: API 호출 로직
+      setStep(2);
+    } catch (error) {
+      console.error('비밀번호 재설정 에러:', error);
+      alert('비밀번호 재설정 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handlePasswordSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      console.log('새로운 비밀번호 설정:', newPassword);
+      // API 호출 로직...
+      alert('비밀번호가 재설정되었습니다.');
+    } catch (error) {
+      console.error('비밀번호 설정 에러:', error);
+      alert('비밀번호 설정 중 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <Box sx={{ width: '300px', margin: '20px auto', textAlign: 'center' }}>
+      <Typography variant="h1" sx={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '10px' }}>
+        F'LINK
+      </Typography>
+      <Typography variant="h2" sx={{ fontSize: '24px', marginBottom: '30px' }}>
+        비밀번호 재설정
+      </Typography>
+      {step === 1 ? (
+        <form onSubmit={handleSubmit}>
+          <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+            <TextField
+              fullWidth
+              id="name"
+              label="성함"
+              placeholder="성함을 입력하세요."
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </Box>
+          <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+            <TextField
+              fullWidth
+              id="email"
+              label="이메일"
+              type="email"
+              placeholder="example@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </Box>
+          <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+            <TextField
+              fullWidth
+              id="phone"
+              label="휴대폰 번호"
+              placeholder="010-0000-0000"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              required
+            />
+          </Box>
+          <Button type="submit" variant="contained" fullWidth>
+            확인
+          </Button>
+        </form>
+      ) : (
+        <form onSubmit={handlePasswordSubmit}>
+          <Box sx={{ marginBottom: '20px', textAlign: 'left' }}>
+            <TextField
+              fullWidth
+              id="newPassword"
+              label="새 비밀번호"
+              type="password"
+              placeholder="새로운 비밀번호 입력"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              required
+            />
+          </Box>
+          <Typography variant="body2" sx={{ fontSize: '14px', color: 'text.secondary', marginBottom: '20px' }}>
+            비밀번호는 영문자와 숫자를 조합하여 8-20자 이내로 설정합니다.
+          </Typography>
+          <Button type="submit" variant="contained" fullWidth>
+            확인
+          </Button>
+        </form>
+      )}
+    </Box>
+  );
+};
+
+export default ResetPassword;

--- a/src/components/LoginPage/AdminLogin.tsx
+++ b/src/components/LoginPage/AdminLogin.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Box, Typography, TextField, Button } from '@mui/material';
+
+const AdminLogin = (): React.JSX.Element => {
+  const [adminId, setAdminId] = useState('');
+
+  const handleLogin = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: 백엔드 API 호출 및 인증 처리
+    console.log('관리자 ID:', adminId);
+    alert('로그인 시도');
+    setAdminId('');
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      {/* 타이틀 */}
+      <Typography variant="h1" sx={{ fontSize: '48px', fontWeight: 'bold', marginBottom: '10px', textAlign: 'center' }}>
+        F'LINK
+      </Typography>
+      <Typography variant="h2" sx={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '30px', textAlign: 'center' }}>
+        관리자 로그인
+      </Typography>
+
+      {/* 로그인 폼 */}
+      <form onSubmit={handleLogin}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', width: '300px', marginBottom: '20px' }}>
+          <TextField
+            fullWidth
+            id="adminId"
+            label="관리자 ID"
+            value={adminId}
+            onChange={(e) => setAdminId(e.target.value)}
+            placeholder="관리자 ID를 입력하세요"
+            required
+          />
+        </Box>
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          sx={{
+            width: '300px',
+            padding: '15px',
+            fontSize: '16px',
+            fontWeight: 'bold',
+          }}
+        >
+          로그인
+        </Button>
+      </form>
+    </Box>
+  );
+};
+
+export default AdminLogin;

--- a/src/components/LoginPage/ParticipantLogin.tsx
+++ b/src/components/LoginPage/ParticipantLogin.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { TextField, Button, Typography, Box } from '@mui/material';
+import PersonIcon from '@mui/icons-material/Person';
+import LockIcon from '@mui/icons-material/Lock';
+import { useNavigate } from 'react-router-dom';
+
+const ParticipantLogin = (): React.JSX.Element => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      // TODO: 실제 API 호출
+      console.log('로그인 시도:', email, password);
+    } catch (error) {
+      console.error('로그인 에러:', error);
+    }
+  };
+
+  const handleKakaoLogin = () => {
+    console.log('카카오 로그인 시도');
+  };
+
+  const handleSignupRedirect = () => {
+    navigate('/signup');
+  };
+
+  const handleFindIdRedirect = () => {
+    navigate('/find-id');
+  };
+
+  const handleFindPasswordRedirect = () => {
+    navigate('/reset-password');
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '100%',
+        maxWidth: 400,
+        margin: 'auto',
+      }}
+    >
+      <Typography variant="h1" sx={{ fontSize: 48, fontWeight: 'bold', mb: 2 }}>
+        F'LINK
+      </Typography>
+      <Typography variant="h6" sx={{ fontSize: 24, mb: 2 }}>
+        사용자 로그인
+      </Typography>
+      <TextField
+        label="이메일"
+        variant="outlined"
+        fullWidth
+        InputProps={{
+          startAdornment: <PersonIcon />,
+        }}
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        margin="normal"
+      />
+      <TextField
+        label="비밀번호"
+        type="password"
+        variant="outlined"
+        fullWidth
+        InputProps={{
+          startAdornment: <LockIcon />,
+        }}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+        margin="normal"
+      />
+      <Button
+        variant="contained"
+        color="primary"
+        type="submit"
+        fullWidth
+        sx={{ mb: 1 }}
+      >
+        로그인
+      </Button>
+      <Button
+        variant="contained"
+        onClick={handleKakaoLogin}
+        fullWidth
+        sx={{ mb: 2, backgroundColor: '#ddd' }}
+      >
+        카카오 로그인
+      </Button>
+      <Box sx={{ textAlign: 'center', mt: 1 }}>
+        <Typography variant="body2" sx={{ color: '#666' }}>
+          처음이신가요?{' '}
+          <Box
+            component="span"
+            onClick={handleSignupRedirect}
+            sx={{
+              cursor: 'pointer',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            간편가입 하기
+          </Box>
+        </Typography>
+      </Box>
+      <Box sx={{ textAlign: 'center', mt: 1 }}>
+        <Typography variant="body2" sx={{ color: '#666' }}>
+          아이디/비밀번호를 잊었어요{' '}
+          <Box
+            component="span"
+            onClick={handleFindIdRedirect}
+            sx={{
+              cursor: 'pointer',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            아이디 찾기
+          </Box>{' '}
+          |{' '}
+          <Box
+            component="span"
+            onClick={handleFindPasswordRedirect}
+            sx={{
+              cursor: 'pointer',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+            }}
+          >
+            비밀번호 찾기
+          </Box>
+        </Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default ParticipantLogin;

--- a/src/components/SignupPage/Signup.tsx
+++ b/src/components/SignupPage/Signup.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+import { Box, Typography, TextField, Checkbox, Button, FormControlLabel } from '@mui/material';
+
+const Signup = (): React.JSX.Element => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [ticketCode, setTicketCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
+  const [agreePersonalInfo, setAgreePersonalInfo] = useState(false);
+  const [agreeTerms, setAgreeTerms] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      // TODO: 회원가입 API 호출 
+      console.log('회원가입 시도:', { name, email, ticketCode, password, phone });
+      alert('회원가입이 완료되었습니다.');
+    } catch (error) {
+      console.error('회원가입 에러:', error);
+      alert('회원가입 중 오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '100%',
+        maxWidth: 400,
+        margin: '0 auto',
+      }}
+    >
+      <Typography variant="h1" sx={{ fontSize: 48, fontWeight: 'bold', mb: 1, textAlign: 'center' }}>
+        F'LINK
+      </Typography>
+      <Typography variant="h2" sx={{ fontSize: 24, fontWeight: 'bold', mb: 3, textAlign: 'center' }}>
+        간편 회원가입
+      </Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ width: '100%' }}>
+        <TextField
+          fullWidth
+          label="성함"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          margin="normal"
+        />
+        <TextField
+          fullWidth
+          label="이메일"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          margin="normal"
+        />
+        <TextField
+          fullWidth
+          label="F'LINK 티켓 코드"
+          value={ticketCode}
+          onChange={(e) => setTicketCode(e.target.value)}
+          required
+          margin="normal"
+        />
+        <TextField
+          fullWidth
+          label="비밀번호"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          margin="normal"
+        />
+        <TextField
+          fullWidth
+          label="휴대폰 번호"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+          margin="normal"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={agreePersonalInfo}
+              onChange={() => setAgreePersonalInfo(!agreePersonalInfo)}
+            />
+          }
+          label="개인정보 수집에 동의합니다."
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={agreeTerms}
+              onChange={() => setAgreeTerms(!agreeTerms)}
+            />
+          }
+          label="이용 약관에 동의합니다."
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          fullWidth
+          sx={{ mt: 2 }}
+        >
+          가입 완료
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default Signup;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,6 +3,12 @@ import DefaultLayout from './layouts/Default';
 import Home from './pages/Home';
 import NotFound from './pages/NotFound';
 import AdminLayout from './layouts/Admin';
+import LoginPage from './pages/ParticipantLoginPage';
+import RoleSelectionPage from './pages/RoleSelectionPage';
+import AdminLoginPage from './pages/AdminLoginPage';
+import SignupPage from './pages/SignupPage';
+import FindIdPage from './pages/FindIdPage';
+import ResetPasswordPage from './pages/ResetPasswordPage';
 import OnBoarding from './pages/OnBoarding';
 
 const router = createBrowserRouter([
@@ -12,6 +18,30 @@ const router = createBrowserRouter([
       {
         path: '/',
         element: <Home />,
+      },
+	    {
+		    path: '/participant-login',
+		    element: <LoginPage />,
+	    },
+	    {
+		    path:'/rolesection',
+		    element: <RoleSelectionPage/>,
+	    },
+      {
+          path: '/admin-login',
+          element: <AdminLoginPage/>,
+      },
+      {
+        path: '/signup',
+        element: <SignupPage/>,
+      },
+      {
+        path: '/find-id',
+        element: <FindIdPage/>,
+      },
+      {
+        path: '/reset-password',
+        element: <ResetPasswordPage/>,
       },
       {
         path: '/onboarding',

--- a/src/routes/pages/AdminLoginPage.tsx
+++ b/src/routes/pages/AdminLoginPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import AdminLogin from '@components/LoginPage/AdminLogin';
+
+const AdminLoginPage = (): React.JSX.Element => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <AdminLogin />
+    </Box>
+  );
+};
+
+export default AdminLoginPage;

--- a/src/routes/pages/FindIdPage.tsx
+++ b/src/routes/pages/FindIdPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import FindId from '@components/AccountPage/FindId';
+
+const FindIdPage = (): React.JSX.Element => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <FindId />
+    </Box>
+  );
+};
+
+export default FindIdPage;

--- a/src/routes/pages/ParticipantLoginPage.tsx
+++ b/src/routes/pages/ParticipantLoginPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import ParticipantLogin from '@components/LoginPage/ParticipantLogin';
+
+const ParticipantLoginPage = (): React.JSX.Element => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        boxSizing: 'border-box',
+      }}
+    >
+      <ParticipantLogin />
+    </Box>
+  );
+};
+
+export default ParticipantLoginPage;

--- a/src/routes/pages/ResetPasswordPage.tsx
+++ b/src/routes/pages/ResetPasswordPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import ResetPassword from '@components/AccountPage/ResetPassword';
+
+const ResetPasswordPage = (): React.JSX.Element => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <ResetPassword />
+    </Box>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/routes/pages/RoleSelectionPage.tsx
+++ b/src/routes/pages/RoleSelectionPage.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+const RoleSelectionPage = (): React.JSX.Element => {
+  const navigate = useNavigate();
+
+  const handleRoleSelection = (roleName: string) => {
+    if (roleName === '참가자') {
+      navigate('/participant-login');
+    } else if (roleName === '관리자') {
+      navigate('/admin-login');
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <Typography
+        variant="h1"
+        sx={{
+          fontSize: { xs: 36, md: 48 },
+          fontWeight: 'bold',
+          marginBottom: 2,
+          textAlign: 'center',
+        }}
+      >
+        F'LINK
+      </Typography>
+
+      <Typography
+        variant="h2"
+        sx={{
+          fontSize: { xs: 20, md: 24 },
+          fontWeight: 'bold',
+          marginBottom: 4,
+          textAlign: 'center',
+        }}
+      >
+        FLINK2025
+      </Typography>
+
+      <Button
+        variant="contained"
+        onClick={() => handleRoleSelection('참가자')}
+        sx={{
+          width: { xs: '200px', md: '300px' },
+          padding: { xs: '10px', md: '15px' },
+          marginBottom: 2,
+          fontSize: { xs: 14, md: 16 },
+        }}
+      >
+        참가자
+      </Button>
+
+      <Button
+        variant="contained"
+        onClick={() => handleRoleSelection('관리자')}
+        sx={{
+          width: { xs: '200px', md: '300px' },
+          padding: { xs: '10px', md: '15px' },
+          fontSize: { xs: 14, md: 16 },
+        }}
+      >
+        관리자
+      </Button>
+    </Box>
+  );
+};
+
+export default RoleSelectionPage;

--- a/src/routes/pages/SignupPage.tsx
+++ b/src/routes/pages/SignupPage.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import Signup from '@components/SignupPage/Signup';
+
+const SignupPage = (): React.JSX.Element => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      <Signup />
+    </Box>
+  );
+};
+
+export default SignupPage;


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/#7_로그인페이지` → `dev`
<br/>

## ✅ 작업 내용

- AccountPage: 아이디 찾기, 비밀번호 수정 페이지 구현
- LoginPage: 참가자, 관리자 각각 로그인 페이지
- Signup: 참가자 회원가입
- UI만 구성하여  로그인, 회원가입 로직은 구현하지 않은 상태
- 아이디 찾기는 임의의 값 'synergy2025'로 넣은 상태
<br/>

## 🌠 이미지 첨부
1. 직군 선택 후 각 로그인 페이지로 이동

https://github.com/user-attachments/assets/6c668c65-e24f-4a35-8233-02000b13ea99

2. 참가자 로그인 화면에서 회원가입, 아이디 찾기, 비밀번호 재설정 페이지 

https://github.com/user-attachments/assets/78394621-b540-48dd-9d48-14dffc6b7e4b



## 📌 이슈 링크

- #7 
