### PR TITLE
feat(components/AdminHeader): 관리자 페이지 헤더 구현

### DIFF
--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,0 +1,85 @@
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { AppBar, Toolbar, Typography } from '@mui/material';
+import { styled } from '@mui/system';
+
+const Logo = styled(Typography)`
+  flex-grow: 1;
+  background-color: transparent;
+  padding: 5px 10px;
+`;
+
+const NavLink = styled(Link, {
+  shouldForwardProp: (prop) => prop !== 'active',
+})<{ active?: boolean }>(({ theme, active }) => ({
+  color: theme.palette.text.primary,
+  textDecoration: 'none',
+  position: 'relative',
+  padding: '8px 16px',
+  borderRadius: '4px',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
+  ...(active && {
+    fontWeight: 'bold',
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: -2,
+      left: 0,
+      width: '100%',
+      height: 2,
+      backgroundColor: 'black',
+    },
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  }),
+}));
+
+const LogoutButton = styled('button')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: '8px 16px',
+  fontSize: '1rem',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
+}));
+
+const Header = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    //TODO: 로그아웃 로직
+    navigate('/role-selection');
+  };
+
+  return (
+    <AppBar
+      position="static"
+      elevation={0}
+      sx={{
+        backgroundColor: 'transparent',
+        boxShadow: 'none',
+      }}
+    >
+      <Toolbar>
+        <Logo variant="h6">F'LINK</Logo>
+        <NavLink
+          to="/dashboard"
+          active={location.pathname === '/admin'}
+        >
+          대시보드
+        </NavLink>
+        <LogoutButton onClick={handleLogout}>
+          로그아웃
+        </LogoutButton>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Header;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -38,7 +38,7 @@ const router = createBrowserRouter([
         element: <LoginPage />,
       },
       {
-        path: '/rolesection',
+        path: '/role-selection',
         element: <RoleSelectionPage />,
       },
       {

--- a/src/routes/layouts/Admin.tsx
+++ b/src/routes/layouts/Admin.tsx
@@ -1,8 +1,9 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
-
+import Header from '@components/AdminHeader';
 const AdminLayout = () => {
   return (
     <>
+      <Header />
       <Outlet />
       <ScrollRestoration />
     </>


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/#22_관리자_헤더` → `dev`
<br/>

## ✅ 작업 내용
- 로고, 대시보드, 로그아웃 헤더 구성
- 역할 선택 라우트 오타 `rolesection -> role-selection` 으로 수정

<br/>

## 🌠 이미지 첨부

<img width="1512" alt="스크린샷 2025-03-11 오전 10 35 42" src="https://github.com/user-attachments/assets/98846f3f-306c-4ad4-8968-24b064aae34c" />


<br/>

## ✏️ 앞으로의 과제

- 관리자 페이지 컴포넌트 구현

<br/>

## 📌 이슈 링크

- #22 
