### PR TITLE
feat(theme): figma foundation, variable 정의에 따른 theme 정의

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@fontsource/roboto": "^5.2.5",
+        "@fontsource/montserrat": "^5.2.5",
+        "@fontsource/pretendard": "^5.2.5",
         "@mui/icons-material": "^6.4.7",
         "@mui/material": "^6.4.6",
         "@tanstack/react-query": "^5.66.11",
@@ -1056,10 +1057,19 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fontsource/roboto": {
+    "node_modules/@fontsource/montserrat": {
       "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.5.tgz",
-      "integrity": "sha512-70r2UZ0raqLn5W+sPeKhqlf8wGvUXFWlofaDlcbt/S3d06+17gXKr3VNqDODB0I1ASme3dGT5OJj9NABt7OTZQ==",
+      "resolved": "https://registry.npmjs.org/@fontsource/montserrat/-/montserrat-5.2.5.tgz",
+      "integrity": "sha512-/OA+bdg1yqUArDUnEeCqDwgTDiIpvED56TxYskje8UKpsvjl/0A9eNod7IcdHz6/Osi70vo7briRO3la8/u+5Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/pretendard": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/pretendard/-/pretendard-5.2.5.tgz",
+      "integrity": "sha512-UAj3l+Exfx6Sq5hySbhTQhNzkZnhzBxQdHySmjo2lifXyXpMAHv7GD7hAQTLgZfBd1WixJJkmynfJbOp+TAckg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@fontsource/roboto": "^5.2.5",
+    "@fontsource/montserrat": "^5.2.5",
+    "@fontsource/pretendard": "^5.2.5",
     "@mui/icons-material": "^6.4.7",
     "@mui/material": "^6.4.6",
     "@tanstack/react-query": "^5.66.11",

--- a/src/@types/mui.d.ts
+++ b/src/@types/mui.d.ts
@@ -1,11 +1,68 @@
 import '@mui/material/styles';
-import { CustomThemeType } from '@styles/theme';
+import { RadiusType, TypoType, FontType } from '@styles/theme';
 
 declare module '@mui/material/styles' {
   interface Theme {
-    custom: CustomThemeType;
+    radius: RadiusType;
+    typo: TypoType;
   }
   interface ThemeOptions {
-    custom?: CustomThemeType;
+    radius?: RadiusType;
+    typo?: TypoType;
+  }
+
+  interface TypeText {
+    tertiary: string;
+    quaternary: string;
+    inverse: string;
+    warning: string;
+    interactive: string;
+  }
+
+  interface TypeBackground {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    quaternary: string;
+    inverse: string;
+    interactive: string;
+  }
+
+  interface TypeName {
+    primary: string;
+  }
+  interface TypeBorder {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    dark_warning: string;
+    interactive: string;
+  }
+
+  interface TypeDividerCustom {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    dark_warning: string;
+    inverse: string;
+    interactive: string;
+  }
+
+  interface TypeOpacity {
+    opa100: string;
+    opa200: string;
+  }
+  interface Palette {
+    name: TypeName;
+    border: TypeBorder;
+    divider_custom: TypeDividerCustom;
+    opacity: TypeOpacity;
+  }
+
+  interface PaletteOptions {
+    name?: TypeName;
+    border?: TypeBorder;
+    divider_custom?: TypeDividerCustom;
+    opacity?: TypeOpacity;
   }
 }

--- a/src/routes/layouts/Admin.tsx
+++ b/src/routes/layouts/Admin.tsx
@@ -1,11 +1,24 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
+import { css, useTheme } from '@mui/material';
 
 const AdminLayout = () => {
+  const { palette } = useTheme();
   return (
-    <>
+    <div
+      css={css`
+        min-height: 100vh;
+        min-height: 100svh;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 1rem;
+        box-shadow: 0 0 20px #0000000d;
+        position: relative;
+        background-color: ${palette.background.primary};
+      `}
+    >
       <Outlet />
       <ScrollRestoration />
-    </>
+    </div>
   );
 };
 

--- a/src/routes/layouts/Default.tsx
+++ b/src/routes/layouts/Default.tsx
@@ -1,21 +1,24 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
-import styled from '@emotion/styled';
-
-const Layout = styled.div`
-  display: flex;
-  flex-direction: column;
-  min-height: 100%;
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 1rem;
-  box-shadow: 0 0 20px #0000000d;
-`;
+import { css, useTheme } from '@mui/material';
 
 export default function DefaultLayout() {
+  const { palette } = useTheme();
+
   return (
-    <Layout>
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        min-height: 100%;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 1rem;
+        box-shadow: 0 0 20px #0000000d;
+        background-color: ${palette.background.primary};
+      `}
+    >
       <Outlet />
       <ScrollRestoration />
-    </Layout>
+    </div>
   );
 }

--- a/src/routes/layouts/DefaultNav.tsx
+++ b/src/routes/layouts/DefaultNav.tsx
@@ -1,14 +1,27 @@
 import { NavLink, Outlet, ScrollRestoration } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { Button } from '@mui/material';
+import { Button, css, useTheme } from '@mui/material';
 
 const DefaultNavLayout = () => {
+  const { palette } = useTheme();
+
   return (
-    <Layout>
+    <div
+      css={css`
+        min-height: 100vh;
+        min-height: 100svh;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 1rem;
+        box-shadow: 0 0 20px #0000000d;
+        position: relative;
+        background-color: ${palette.background.primary};
+      `}
+    >
       <Outlet />
       <ScrollRestoration />
       <Navigation />
-    </Layout>
+    </div>
   );
 };
 
@@ -29,16 +42,6 @@ const Navigation = () => {
     </Nav>
   );
 };
-
-const Layout = styled.div`
-  min-height: 100vh;
-  min-height: 100svh;
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 1rem;
-  box-shadow: 0 0 20px #0000000d;
-  position: relative;
-`;
 
 const Nav = styled.nav`
   display: flex;

--- a/src/styles/foundation/index.ts
+++ b/src/styles/foundation/index.ts
@@ -1,0 +1,59 @@
+export { color, typography, radius };
+
+const color = {
+  gray0: '#171717',
+  gray100: '#1e1e1e',
+  gray200: '#292929',
+  gray300: '#333333',
+  gray400: '#3a3a3a',
+  gray500: '#434343',
+  gray500a: '#43434380',
+  gray600: '#949494',
+  gray700: '#b2b2b2',
+  gray700a: '#b2b2b280',
+  gray800: '#d4d4d4',
+  gray900: '#f5f5f5',
+  blue0: '#094b4a',
+  blue100: '#0c605f',
+  blue200: '#10807f',
+  blue300: '#14a09f',
+  blue400: '#16aaaa',
+  blue500: '#18c0bf',
+  blue600: '#1bd5d4',
+  blue700: '#b8f2f2',
+  blue800: '#ddf9f9',
+  blue900: '#e8fbfb',
+  red100: '#a82a35',
+  red500: '#fa3f4f',
+} as const;
+
+const typography = {
+  fontFamily: {
+    Pretendard: 'Pretendard',
+    Montserrat: 'Montserrat',
+  },
+  title: {
+    l: { fontSize: '26px', fontWeight: 'bold' },
+    m: { fontSize: '24px', fontWeight: 'bold' },
+    s: { fontSize: '22px', fontWeight: 'bold' },
+    xs: { fontSize: '20px', fontWeight: 'bold' },
+  },
+  sub: {
+    l: { fontSize: '18px', fontWeight: 'bold' },
+    m: { fontSize: '16px', fontWeight: 'bold' },
+    s: { fontSize: '14px', fontWeight: 'bold' },
+  },
+  body: {
+    l: { fontSize: '18px', fontWeight: 'normal' },
+    m: { fontSize: '16px', fontWeight: 'normal' },
+    s: { fontSize: '14px', fontWeight: 'normal' },
+  },
+} as const;
+
+const radius = {
+  xl: '18px', // List, Modal, Card
+  lg: '16px', // ListSet
+  md: '12px', // CTA, Banner, BorderButton
+  sm: '10px', // Border, Popup, Card, Image
+  xs: '8px', // Input field
+} as const;

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -1,4 +1,16 @@
 import { css } from '@emotion/react';
+import '@fontsource/montserrat/400.css';
+import '@fontsource/montserrat/500.css';
+import '@fontsource/montserrat/600.css';
+import '@fontsource/montserrat/700.css';
+import '@fontsource/montserrat/800.css';
+import '@fontsource/montserrat/900.css';
+import '@fontsource/pretendard/400.css';
+import '@fontsource/pretendard/500.css';
+import '@fontsource/pretendard/600.css';
+import '@fontsource/pretendard/700.css';
+import '@fontsource/pretendard/800.css';
+import '@fontsource/pretendard/900.css';
 
 export const globalStyles = css`
   * {
@@ -145,13 +157,6 @@ export const globalStyles = css`
   }
   input:focus {
     outline: none;
-  }
-  @font-face {
-    font-family: 'Pretendard';
-    font-style: normal;
-    font-weight: 700;
-    src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
-      format('woff');
   }
 
   html,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,51 +1,59 @@
 import { createTheme } from '@mui/material/styles';
+import { color, radius, typography } from './foundation';
 
-const customTheme = {
-  color: {
-    black: '#222',
-    primary: '#a1c4fd',
-    gray500: '#555',
-  },
-  fontSize: {
-    small: '14px',
-    medium: '16px',
-    title: '42px',
-    subtitle: '20px',
-  },
-  border: {
-    primary: '#e5e7eb',
-  },
-} as const;
-
-export type CustomThemeType = typeof customTheme;
+export type RadiusType = typeof radius;
+export type TypoType = typeof typography;
 
 const theme = createTheme({
   palette: {
-    primary: {
-      main: '#a1c4fd',
-    },
+    name: { primary: color.red500 },
     text: {
-      primary: '#222',
-      secondary: '#555',
+      primary: color.gray900,
+      secondary: color.gray800,
+      tertiary: color.gray700,
+      quaternary: color.gray600,
+      inverse: color.gray0,
+      warning: color.red500,
+      interactive: color.blue500,
+    },
+    background: {
+      primary: color.gray0,
+      secondary: color.gray200,
+      tertiary: color.gray300,
+      quaternary: color.gray500,
+      inverse: color.gray100,
+      interactive: color.blue300,
+    },
+    border: {
+      primary: color.gray500,
+      secondary: color.gray600,
+      tertiary: color.gray400,
+      dark_warning: color.red100,
+      interactive: '미정',
+    },
+    divider_custom: {
+      primary: color.gray500,
+      secondary: color.gray600,
+      tertiary: color.gray400,
+      dark_warning: color.red100,
+      inverse: '미정',
+      interactive: '미정',
+    },
+    opacity: {
+      opa100: color.gray500a,
+      opa200: color.gray700a,
     },
   },
+  radius,
+  typo: typography,
   typography: {
-    fontFamily: 'Pretendard',
-    fontSize: 16,
-    h1: {
-      fontSize: '42px',
-    },
-    h2: {
-      fontSize: '20px',
-    },
-    body1: {
-      fontSize: '14px',
-    },
+    fontFamily: typography.fontFamily.Pretendard,
   },
   components: {
     MuiButton: {
       styleOverrides: {
         root: {
+          fontFamily: typography.fontFamily.Pretendard,
           borderRadius: '8px',
           border: '2px solid #ddd',
           backgroundColor: 'white',
@@ -55,12 +63,11 @@ const theme = createTheme({
     MuiCheckbox: {
       styleOverrides: {
         root: {
-          fontFamily: 'Pretendard',
+          fontFamily: typography.fontFamily.Pretendard,
         },
       },
     },
   },
-  custom: customTheme,
 });
 
 export default theme;


### PR DESCRIPTION
## 🚀 반영 브랜치

`style/foundation` → `dev`

<br/>

## ✅ 작업 내용

- montserrat,pretendard fontsource 의존성 설치 및 적용
- foundation에 따른 상수 정의
- theme 적용에 따른 mui.d.ts 타입 정의

<br/>

## 📝 사용 방법

1. `useTheme`를 사용하여 `src/styles/theme.ts`에 정의된 theme를 가져온다.
2. figma 에 디자인된 내용을 바탕으로 내부에 정의된 객체값을 이용한다

![image](https://github.com/user-attachments/assets/4f5a5da0-ca50-4676-8f2f-757e68e52ca2)

```typescript
// 위 피그마 사진에 대한 예시
import { css, useTheme } from '@mui/material';

const Home = () => {
  const { palette, typo } = useTheme();

  return (
    <h1
      css={css`
        font-family: ${typo.fontFamily.Montserrat};
        font-size: ${typo.title.l.fontSize};
        font-weight: ${typo.title.l.fontWeight};
        background-color: ${palette.background.primary};
        color: ${palette.text.warning};
        width: 100px;
        height: 100px;
      `}
    >
      현재 어떤 일을 하고 계신가요?
    </h1>
  );
};

export default Home;

```

<br/>

## 📌 이슈 링크

- #4
