### PR TITLE
style(onboarding): Hi-Fi 반영한 온보딩 페이지 컴포넌트 스타일링 수정

### DIFF
--- a/src/@types/mui.d.ts
+++ b/src/@types/mui.d.ts
@@ -24,6 +24,7 @@ declare module '@mui/material/styles' {
     secondary: string;
     tertiary: string;
     quaternary: string;
+    quinary: string;
     inverse: string;
     interactive: string;
   }
@@ -52,11 +53,20 @@ declare module '@mui/material/styles' {
     opa100: string;
     opa200: string;
   }
+
+  interface TypeIcon {
+    primary: string;
+    secondary: string;
+    tertiary: string;
+    inverse: string;
+  }
+
   interface Palette {
     name: TypeName;
     border: TypeBorder;
     divider_custom: TypeDividerCustom;
     opacity: TypeOpacity;
+    icon: TypeIcon;
   }
 
   interface PaletteOptions {
@@ -64,5 +74,6 @@ declare module '@mui/material/styles' {
     border?: TypeBorder;
     divider_custom?: TypeDividerCustom;
     opacity?: TypeOpacity;
+    icon?: TypeIcon;
   }
 }

--- a/src/components/ErrorPopover.tsx
+++ b/src/components/ErrorPopover.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
-import { css, keyframes } from '@emotion/react';
+import { keyframes } from '@emotion/react';
+import { css, useTheme } from '@mui/material';
 
 const ErrorPopover = ({ error }: { error: string | null }) => {
+  const { palette } = useTheme();
   const [visible, setVisible] = useState(false);
   const [key, setKey] = useState(0); // UI 갱신을 위한 키값
 
@@ -28,16 +30,20 @@ const ErrorPopover = ({ error }: { error: string | null }) => {
         top: 20px;
         left: 50%;
         transform: translateX(-50%);
-        background-color: rgba(255, 0, 0, 0.7);
-        color: white;
-        padding: 12px 20px;
-        border-radius: 8px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background-color: ${palette.opacity.opa200};
+        color: ${palette.text.primary};
+        padding: 10px;
+        border-radius: 20px;
         box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
         font-weight: bold;
         animation:
           ${shake} 0.3s ease-in-out,
           ${fadeOut} 2.5s ease-in-out 0.5s forwards;
         z-index: 1000;
+        width: 327px;
       `}
     >
       {error}

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -1,28 +1,38 @@
-import { css, FormControl, Input, InputLabel } from '@mui/material';
+import { css, FormControl, Input, useTheme } from '@mui/material';
 
 interface Props {
   label: string;
   id: string;
-  isRequired: boolean;
+  isRequired?: boolean;
   placeholder?: string;
   onChange?: (value: string) => void;
 }
 
 const InputBox = ({ label, id, isRequired, placeholder, onChange }: Props) => {
+  const { palette, typo, radius } = useTheme();
+
   return (
-    <FormControl
-      required={isRequired}
-      css={css`
-        border: 1px solid #ddd;
-        padding: 10px;
-        border-radius: 10px;
-      `}
-    >
-      <InputLabel>{label}</InputLabel>
+    <FormControl required={isRequired}>
+      <span
+        css={css`
+          ${typo.sub.m}
+          color: ${palette.text.primary};
+          margin-bottom: 8px;
+        `}
+      >
+        {`${label} ${isRequired ? '*' : ''}`}
+      </span>
       <Input
+        disableUnderline
         id={id}
         placeholder={placeholder || ''}
         onChange={(e) => onChange?.(e.target.value)}
+        css={css`
+          border: 1px solid ${palette.border.secondary};
+          border-radius: ${radius.sm};
+          padding: 11px 20px 10px;
+          background-color: ${palette.background.quaternary};
+        `}
       />
     </FormControl>
   );

--- a/src/components/SelectBox.tsx
+++ b/src/components/SelectBox.tsx
@@ -1,29 +1,77 @@
-import { css, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
-
+import { css, FormControl, MenuItem, Select, useTheme } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 interface Props {
   id: string;
   label: string;
   items: { value: string | number; text: string }[];
-  value: string | number | null;
-  onChange: (value: string | number) => void;
+  value: string;
+  onChange: (value: string) => void;
   disabled?: boolean;
+  isRequired?: boolean;
+  placeholder?: string;
 }
 
-const SelectBox = ({ id, label, items, value, onChange, disabled }: Props) => {
+const SelectBox = ({
+  id,
+  label,
+  items,
+  value,
+  onChange,
+  disabled,
+  isRequired,
+  placeholder,
+}: Props) => {
+  const { palette, typo, radius } = useTheme();
+
   return (
     <FormControl
       fullWidth
       disabled={disabled}
-      css={css`
-        width: 370px;
-      `}
+      sx={{
+        '& .MuiSelect-root.Mui-disabled': {
+          backgroundColor: palette.opacity.opa200,
+          opacity: 0.5,
+        },
+      }}
     >
-      <InputLabel id={`${id}-label`}>{label}</InputLabel>
+      <span
+        css={css`
+          ${typo.sub.m}
+          color: ${palette.text.primary};
+          opacity: ${disabled && 0.4};
+          margin-bottom: 8px;
+        `}
+      >
+        {`${label} ${isRequired ? '*' : ''}`}
+      </span>
       <Select
+        displayEmpty
         labelId={`${id}-label`}
         id={id}
-        value={value ?? ''}
+        value={value}
+        renderValue={(v) => (v ? value : placeholder)}
         onChange={(e) => onChange(e.target.value)}
+        css={css`
+          padding-left: 10px;
+          border-radius: ${radius.sm};
+          border: 1px solid ${palette.border.secondary};
+          color: ${palette.text.tertiary};
+          background-color: ${palette.background.quaternary};
+        `}
+        sx={{
+          '.MuiSvgIcon-root ': {
+            fill: 'white !important',
+          },
+        }}
+        IconComponent={(props) => (
+          <KeyboardArrowDownIcon
+            css={css`
+              margin-right: 15px;
+            `}
+            color={palette.icon.primary}
+            {...props}
+          />
+        )}
       >
         {items.map((item) => (
           <MenuItem key={item.value} value={item.value}>

--- a/src/components/TextareaBox.tsx
+++ b/src/components/TextareaBox.tsx
@@ -1,4 +1,5 @@
-import { TextField } from '@mui/material';
+import { css, FormControl, InputBase, useTheme } from '@mui/material';
+import { useState } from 'react';
 
 interface Props {
   label: string;
@@ -6,18 +7,76 @@ interface Props {
   isRequired: boolean;
   placeholder?: string;
   onChange?: (value: string) => void;
+  max_length: number;
 }
 
-const TextareaBox = ({ label, id, isRequired, onChange }: Props) => {
+const TextareaBox = ({
+  label,
+  id,
+  isRequired,
+  onChange,
+  placeholder,
+  max_length,
+}: Props) => {
+  const { typo, palette } = useTheme();
+  const [text, setText] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+    onChange?.(e.target.value);
+  };
   return (
-    <TextField
-      id={id}
-      label={label}
-      multiline
-      rows={5}
-      required={isRequired}
-      onChange={(e) => onChange?.(e.target.value)}
-    />
+    <FormControl required={isRequired}>
+      <span
+        css={css`
+          ${typo.sub.m}
+          color: ${palette.text.primary};
+          margin-bottom: 8px;
+        `}
+      >
+        {`${label} ${isRequired ? '*' : ''}`}
+      </span>
+      <InputBase
+        id={id}
+        multiline
+        inputProps={{ maxLength: max_length }}
+        rows={5}
+        required={isRequired}
+        onChange={handleChange}
+        placeholder={placeholder || ''}
+        css={css`
+          border: 1px solid ${palette.border.secondary};
+          border-radius: 10px;
+          padding: 15px 20px;
+          background-color: ${palette.background.quaternary};
+        `}
+        sx={{
+          '& ::-webkit-scrollbar': {
+            width: '5px',
+          },
+          '& ::-webkit-scrollbar-track': {
+            background: palette.background.quaternary,
+          },
+          '& ::-webkit-scrollbar-thumb': {
+            backgroundColor: palette.background.secondary,
+          },
+          '& ::-webkit-scrollbar-thumb:hover': {
+            background: '#555',
+          },
+        }}
+      />
+      <span
+        css={css`
+          display: flex;
+          justify-content: flex-end;
+          margin-top: 4px;
+          font-size: 10px;
+          color: ${palette.text.secondary};
+        `}
+      >
+        {text.length}/{max_length}
+      </span>
+    </FormControl>
   );
 };
 

--- a/src/components/onboarding-process/Info.tsx
+++ b/src/components/onboarding-process/Info.tsx
@@ -2,57 +2,47 @@ import { useState } from 'react';
 import InputBox from '@components/InputBox';
 import SelectBox from '@components/SelectBox';
 import TextareaBox from '@components/TextareaBox';
-import { Button, css, Typography } from '@mui/material';
+import { Button, css, useTheme } from '@mui/material';
 import {
+  age_range,
   company_culture,
   company_type,
   conference_purpose,
+  education_levels,
   experience_range,
   hope_job,
+  location,
   salary_range,
 } from 'src/constant/onboarding';
 import { Infos } from 'src/types/funnel/onboarding.type';
 
 const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
+  const { palette, typo, radius } = useTheme();
+
   const [info, setInfo] = useState<Infos>({
+    // 필수 속성
     hope_job: '',
+    education: '',
+    age: '',
     skills: '',
     experience: '',
-    others_experience: '',
+    hope_location: '',
+    profile_img: '',
     cover_letter: '',
-    location: '',
+    // 선택 속성
+    others_experience: '',
+    salary: '',
     company: '',
     culture: '',
     purpose: '',
-    salary: '',
   });
 
-  const handleChange = (key: keyof Infos, value: string | number) => {
+  const handleChange = (key: keyof Infos, value: string) => {
     setInfo((prev) => ({ ...prev, [key]: value }));
   };
 
   return (
     <>
-      <Typography
-        variant="h1"
-        css={css`
-          font-size: 28px;
-        `}
-      >
-        채용 담당자를 위한 <br /> 추가 정보를 입력해주세요!
-      </Typography>
-
-      <Typography
-        variant="inherit"
-        css={css`
-          font-size: 17px;
-          margin: 17px 0px 47px;
-        `}
-        color="#717171"
-      >
-        작성한 내용을 채용 담당자가 볼 수 있습니다.
-      </Typography>
-
       <div
         css={css`
           display: flex;
@@ -68,13 +58,37 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           items={hope_job}
           value={info.hope_job}
           onChange={(value) => handleChange('hope_job', value)}
+          isRequired
+          placeholder="희망 직무를 선택해 주세요."
+        />
+
+        {/* 학력 선택 */}
+        <SelectBox
+          id="education"
+          label="학력"
+          items={education_levels}
+          value={info.education}
+          onChange={(value) => handleChange('education', value)}
+          isRequired
+          placeholder="학력을 선택해 주세요."
+        />
+
+        {/* 연령대 선택 */}
+        <SelectBox
+          id="age"
+          label="연령대"
+          items={age_range}
+          value={info.age}
+          onChange={(value) => handleChange('age', value)}
+          isRequired
+          placeholder="연령대를 선택해 주세요."
         />
 
         {/* 보유 기술 */}
         <InputBox
           label="보유 기술"
           id="skills"
-          isRequired={true}
+          isRequired
           placeholder="ex) java, aws ..."
           onChange={(value) => handleChange('skills', value)}
         />
@@ -86,14 +100,47 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           items={experience_range}
           value={info.experience}
           onChange={(value) => handleChange('experience', value)}
+          isRequired
+          placeholder="경력을 선택해주세요."
+        />
+
+        {/* 희망 근무 지역 */}
+        <SelectBox
+          id="hope_location"
+          label="희망 근무 지역"
+          items={location}
+          value={info.hope_location}
+          onChange={(value) => handleChange('hope_location', value)}
+          isRequired
+          placeholder="희망하는 근무 지역을 선택해주세요."
         />
 
         {/* 경험 및 기타 정보 */}
         <InputBox
-          label="경험 및 기타 정보"
+          id="profile_img"
+          label="증명사진"
+          isRequired
+          onChange={(value) => handleChange('profile_img', value)}
+          placeholder="JPG, PNG 파일 업로드"
+        />
+
+        {/* 자기소개서 */}
+        <TextareaBox
+          id="cover_letter"
+          label="자기소개서"
+          isRequired
+          onChange={(value) => handleChange('cover_letter', value)}
+          placeholder="자기소개를 400자 이내로 작성해주세요."
+          max_length={400}
+        />
+
+        {/* 경험 및 기타 정보 */}
+        <InputBox
           id="others_experience"
+          label="경험 및 기타 정보"
           isRequired={false}
           onChange={(value) => handleChange('others_experience', value)}
+          placeholder="상세 경력 및 경험을 작성해 주세요."
         />
 
         {/* 희망 연봉 */}
@@ -101,16 +148,9 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           id="salary"
           label="희망 연봉"
           items={salary_range}
-          value={info.salary ?? null}
+          value={info.salary || ''}
           onChange={(value) => handleChange('salary', value)}
-        />
-
-        {/* 희망 근무 지역 */}
-        <InputBox
-          label="희망 근무 지역"
-          id="location"
-          isRequired={false}
-          onChange={(value) => handleChange('location', value)}
+          placeholder="희망 연봉을 선택해 주세요."
         />
 
         {/* 직장 선택 요소 */}
@@ -118,7 +158,7 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           id="company"
           label="희망 회사 규모"
           items={company_type}
-          value={info.company ?? null}
+          value={info.company || ''}
           onChange={(value) => handleChange('company', value)}
         />
 
@@ -127,7 +167,7 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           id="culture"
           label="선호하는 기업 문화"
           items={company_culture}
-          value={info.culture ?? null}
+          value={info.culture || ''}
           onChange={(value) => handleChange('culture', value)}
         />
 
@@ -136,27 +176,24 @@ const Info = ({ onSubmit }: { onSubmit: (info: Infos) => void }) => {
           id="purpose"
           label="컨퍼런스 참여 목적"
           items={conference_purpose}
-          value={info.purpose ?? null}
+          value={info.purpose || ''}
           onChange={(value) => handleChange('purpose', value)}
-        />
-
-        {/* 자기소개서 */}
-        <TextareaBox
-          label="자기소개서"
-          id="cover_letter"
-          isRequired={false}
-          onChange={(value) => handleChange('cover_letter', value)}
         />
       </div>
 
       {/* submit */}
       <Button
         onClick={() => onSubmit(info)}
-        sx={{
-          width: '100%',
-          backgroundColor: '#ddd',
-          marginTop: '50px',
-        }}
+        css={css`
+          ${typo.sub.l}
+          color: ${palette.text.primary};
+          background-color: ${palette.background.quinary};
+          border: none;
+          width: 100%;
+          margin-top: 20px;
+          border-radius: ${radius.md};
+          height: 50px;
+        `}
       >
         완료
       </Button>

--- a/src/components/onboarding-process/Interested.tsx
+++ b/src/components/onboarding-process/Interested.tsx
@@ -1,18 +1,22 @@
 import {
   Button,
   Checkbox,
+  css,
   FormControlLabel,
   FormGroup,
   Typography,
+  useTheme,
 } from '@mui/material';
 import { useState } from 'react';
 import { checkboxItems } from 'src/constant/onboarding';
-
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 interface Props {
   onNext: (interested_list: string[]) => void;
 }
 
 const Interested = (props: Props) => {
+  const { palette, typo, radius } = useTheme();
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
 
   const handleCheckboxChange = (id: string) => {
@@ -23,7 +27,13 @@ const Interested = (props: Props) => {
 
   return (
     <>
-      <Typography variant="h1">
+      <Typography
+        variant="h2"
+        css={css`
+          color: ${palette.text.primary};
+          ${typo.title.l};
+        `}
+      >
         김지원 님! <br />
         지금 정보를 입력하고, <br />
         포인트를 적립하여 <br />
@@ -32,15 +42,16 @@ const Interested = (props: Props) => {
 
       <Typography
         variant="inherit"
-        sx={{ color: 'gray', margin: '18px 0px 47px ' }}
+        css={css`
+          color: ${palette.text.secondary};
+          margin: 12px 0px 36px;
+          ${typo.body.l}
+        `}
       >
         관심 있는 분야를 선택해주세요.
       </Typography>
 
-      <FormGroup
-        row
-        sx={{ columnGap: '20px', rowGap: '13px', maxWidth: '326px' }}
-      >
+      <FormGroup row sx={{ gap: '16px', width: '100%', margin: '0px' }}>
         {checkboxItems.map((item) => (
           <FormControlLabel
             key={item.id}
@@ -49,31 +60,45 @@ const Interested = (props: Props) => {
                 checked={selectedItems.includes(item.id)}
                 onChange={() => handleCheckboxChange(item.id)}
                 sx={{
+                  color: palette.icon.primary,
                   '& .MuiSvgIcon-root': { fontSize: 16 },
+                  '&.Mui-checked': {
+                    color: palette.icon.primary,
+                  },
                   fontSize: '20px',
                 }}
+                icon={<CheckCircleOutlineIcon color={'inherit'} />}
+                checkedIcon={<CheckCircleIcon color={'inherit'} />}
               />
             }
             label={item.label}
-            sx={{
-              margin: 0,
-              border: '1px solid #ddd',
-              borderRadius: '20px',
-              paddingRight: '13px',
-            }}
+            css={css`
+              ${typo.body.m}
+              color: ${palette.text.secondary};
+              border: 1px solid ${palette.border.secondary};
+              border-radius: ${radius.xl};
+              padding-left: 2px;
+              padding-right: 14px;
+              margin: 0;
+            `}
           />
         ))}
       </FormGroup>
 
       <Button
         onClick={() => props.onNext(selectedItems)}
-        sx={{
-          width: '100%',
-          backgroundColor: '#ddd',
-          marginTop: '100px',
-        }}
+        css={css`
+          ${typo.sub.l}
+          color: ${palette.text.primary};
+          background-color: ${palette.background.quinary};
+          border: none;
+          width: 100%;
+          margin-top: 20px;
+          border-radius: ${radius.md};
+          height: 50px;
+        `}
       >
-        다음
+        완료
       </Button>
     </>
   );

--- a/src/components/onboarding-process/Work.tsx
+++ b/src/components/onboarding-process/Work.tsx
@@ -3,16 +3,18 @@ import {
   Checkbox,
   FormControl,
   FormControlLabel,
-  FormLabel,
   Radio,
   RadioGroup,
   Typography,
   css,
+  useTheme,
 } from '@mui/material';
 import { useState } from 'react';
 import { Jobs } from 'src/types/funnel/onboarding.type';
 import { jobs } from 'src/constant/onboarding';
 import SelectBox from '@components/SelectBox';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 
 type ChildJob = {
   value: string;
@@ -23,6 +25,7 @@ interface Props {
 }
 
 const Work = ({ onNext }: Props) => {
+  const { palette, typo, radius } = useTheme();
   const [work, setwork] = useState<Jobs>({
     parent: '',
     child: '',
@@ -46,24 +49,25 @@ const Work = ({ onNext }: Props) => {
   return (
     <>
       <Typography
-        variant="h1"
+        variant="h2"
         css={css`
-          font-size: 28px;
+          ${typo.title.l};
+          color: ${palette.text.primary};
         `}
       >
         현재 어떤 일을 하고 계신가요?
       </Typography>
 
       <Typography
-        variant="inherit"
+        variant="body1"
         css={css`
-          font-size: 17px;
-          margin: 17px 0px 47px;
+          ${typo.body.l};
+          color: ${palette.text.secondary};
+          line-height: 130%;
+          margin: 12px 0px 36px;
         `}
-        color="#717171"
       >
         채용을 희망할 경우 알려주세요! <br />
-        <br />
         관련 혜택을 제공해 드립니다.
       </Typography>
 
@@ -84,6 +88,8 @@ const Work = ({ onNext }: Props) => {
             handleChange('parent', value.toString());
             handleParentChange(value.toString());
           }}
+          isRequired
+          placeholder="현재 직업을 선택해주세요."
         />
 
         {/* 자식 직무 선택 */}
@@ -94,11 +100,20 @@ const Work = ({ onNext }: Props) => {
           value={work.child ?? ''}
           onChange={(value) => handleChange('child', value.toString())}
           disabled={childrenJobs.length === 0}
+          isRequired
+          placeholder="현재 직무를 선택해주세요."
         />
 
         {/* 채용 희망 여부 선택 */}
         <FormControl>
-          <FormLabel>채용 희망 여부</FormLabel>
+          <span
+            css={css`
+              ${typo.sub.m}
+              color: ${palette.text.primary};
+            `}
+          >
+            채용 희망 여부 *
+          </span>
           <RadioGroup
             name="controlled-radio-buttons-group"
             value={work.employeement_agree}
@@ -108,13 +123,40 @@ const Work = ({ onNext }: Props) => {
           >
             <FormControlLabel
               value="yes"
-              control={<Radio size="small" />}
+              control={
+                <Radio
+                  size="small"
+                  sx={{
+                    color: palette.icon.primary,
+                    '&.Mui-checked': {
+                      color: palette.icon.secondary,
+                    },
+                  }}
+                />
+              }
               label="예"
+              css={css`
+                color: ${palette.text.primary};
+              `}
             />
             <FormControlLabel
               value="no"
-              control={<Radio size="small" />}
+              control={
+                <Radio
+                  size="small"
+                  sx={{
+                    color: palette.icon.primary,
+                    '&.Mui-checked': {
+                      color: palette.icon.secondary,
+                    },
+                  }}
+                />
+              }
               label="아니오"
+              css={css`
+                ${typo.body.l}
+                color: ${palette.text.primary};
+              `}
             />
           </RadioGroup>
         </FormControl>
@@ -123,26 +165,47 @@ const Work = ({ onNext }: Props) => {
         <FormControlLabel
           control={
             <Checkbox
+              icon={<CheckCircleOutlineIcon />}
+              checkedIcon={<CheckCircleIcon />}
               checked={work.private_agree}
               onChange={(e) => handleChange('private_agree', e.target.checked)}
               sx={{
-                '& .MuiSvgIcon-root': { fontSize: 20 },
-                fontSize: '13px',
+                color: palette.icon.primary,
+                '& .MuiSvgIcon-root': { fontSize: 16 },
+                '&.Mui-checked': {
+                  color: palette.icon.primary,
+                },
+                fontSize: '20px',
               }}
             />
           }
-          label="개인 정보 수집에 동의합니다."
+          label={
+            <Typography
+              variant="body1"
+              css={css`
+                ${typo.body.m}
+                color: ${palette.text.secondary};
+              `}
+            >
+              개인 정보 수집에 동의합니다.
+            </Typography>
+          }
         />
       </div>
 
       {/* 버튼 클릭 시 조건에 따라 submit 또는 onNext 실행 */}
       <Button
         onClick={() => onNext(work)}
-        sx={{
-          width: '100%',
-          backgroundColor: '#ddd',
-          marginTop: '50px',
-        }}
+        css={css`
+          ${typo.sub.l}
+          color: ${palette.text.primary};
+          background-color: ${palette.background.quinary};
+          border: none;
+          width: 100%;
+          margin-top: 20px;
+          border-radius: ${radius.md};
+          height: 50px;
+        `}
       >
         완료
       </Button>

--- a/src/constant/onboarding.ts
+++ b/src/constant/onboarding.ts
@@ -52,11 +52,9 @@ export const hope_job = jobs.flatMap((job) => job.children);
 // 경력 선택
 export const experience_range = [
   { value: 'entry', text: '신입' },
-  { value: '1-3', text: '1~3년차' },
-  { value: '3-5', text: '3~5년차' },
-  { value: '5-7', text: '5~7년차' },
-  { value: '7-10', text: '7~10년차' },
-  { value: '10+', text: '10년차 이상' },
+  { value: '1-3', text: '1~2년 이하' },
+  { value: '3-5', text: '3~4년 이하' },
+  { value: '5+', text: '5년 이상' },
 ];
 
 // 희망 연봉 선택
@@ -89,4 +87,29 @@ export const conference_purpose = [
   { value: 'learning', text: '최신 기술 트렌드 학습' },
   { value: 'career', text: '커리어 기회 탐색' },
   { value: 'project', text: '프로젝트 아이디어 구상' },
+];
+
+export const location = [
+  { value: 'seoul', text: '서울' },
+  { value: 'gyeonggi', text: '경기' },
+  { value: 'gangwon', text: '강원' },
+  { value: 'gyeongsang', text: '경상' },
+  { value: 'jeolla', text: '전라' },
+  { value: 'chungcheong', text: '충청' },
+  { value: 'jeju', text: '제주' },
+];
+
+export const age_range = [
+  { value: '20-24', text: '20~24세 이하' },
+  { value: '25-29', text: '25~29세 이하' },
+  { value: '30-34', text: '30~34세 이하' },
+  { value: '35+', text: '35세 이상' },
+];
+
+export const education_levels = [
+  { value: 'high_school', text: '고등학교 졸업' },
+  { value: 'associate_degree', text: '2~3년제 대학 졸업' },
+  { value: 'bachelor_degree', text: '4년제 대학 졸업' },
+  { value: 'master_degree', text: '대학원 석사' },
+  { value: 'doctorate', text: '박사' },
 ];

--- a/src/routes/layouts/Default.tsx
+++ b/src/routes/layouts/Default.tsx
@@ -1,8 +1,11 @@
-import { Outlet, ScrollRestoration } from 'react-router-dom';
+import { Outlet, ScrollRestoration, useLocation } from 'react-router-dom';
 import { css, useTheme } from '@mui/material';
 
 export default function DefaultLayout() {
   const { palette } = useTheme();
+  const location = useLocation();
+
+  const isOnboarding = location.pathname === '/onboarding';
 
   return (
     <div
@@ -14,7 +17,9 @@ export default function DefaultLayout() {
         margin: 0 auto;
         padding: 1rem;
         box-shadow: 0 0 20px #0000000d;
-        background-color: ${palette.background.primary};
+        background-color: ${isOnboarding
+          ? palette.background.tertiary
+          : palette.background.primary};
       `}
     >
       <Outlet />

--- a/src/routes/pages/OnBoarding.tsx
+++ b/src/routes/pages/OnBoarding.tsx
@@ -5,7 +5,7 @@ import {
   SelectWork,
 } from '../../types/funnel/onboarding.type';
 import Interested from '@components/onboarding-process/Interested';
-import { css, useTheme } from '@mui/material';
+import { css } from '@mui/material';
 import Work from '@components/onboarding-process/Work';
 import Info from '@components/onboarding-process/Info';
 import {

--- a/src/routes/pages/OnBoarding.tsx
+++ b/src/routes/pages/OnBoarding.tsx
@@ -5,7 +5,7 @@ import {
   SelectWork,
 } from '../../types/funnel/onboarding.type';
 import Interested from '@components/onboarding-process/Interested';
-import { css } from '@emotion/react';
+import { css, useTheme } from '@mui/material';
 import Work from '@components/onboarding-process/Work';
 import Info from '@components/onboarding-process/Info';
 import {
@@ -44,7 +44,6 @@ const OnBoarding = () => {
         display: flex;
         flex-direction: column;
         justify-content: center;
-        align-items: center;
         height: 100%;
         margin: auto 0;
       `}

--- a/src/styles/foundation/index.ts
+++ b/src/styles/foundation/index.ts
@@ -33,20 +33,21 @@ const typography = {
     Montserrat: 'Montserrat',
   },
   title: {
-    l: { fontSize: '26px', fontWeight: 'bold' },
-    m: { fontSize: '24px', fontWeight: 'bold' },
-    s: { fontSize: '22px', fontWeight: 'bold' },
-    xs: { fontSize: '20px', fontWeight: 'bold' },
+    l: { fontSize: '26px', fontWeight: 'bold', lineHeight: 'normal' },
+    m: { fontSize: '24px', fontWeight: 'bold', lineHeight: 'normal' },
+    s: { fontSize: '22px', fontWeight: 'bold', lineHeight: 'normal' },
+    xs: { fontSize: '20px', fontWeight: 'bold', lineHeight: 'normal' },
   },
   sub: {
-    l: { fontSize: '18px', fontWeight: 'bold' },
-    m: { fontSize: '16px', fontWeight: 'bold' },
-    s: { fontSize: '14px', fontWeight: 'bold' },
+    l: { fontSize: '18px', fontWeight: 'bold', lineHeight: 'normal' },
+    m: { fontSize: '17px', fontWeight: 'bold', lineHeight: 'normal' },
+    s: { fontSize: '16px', fontWeight: 'bold', lineHeight: 'normal' },
+    xs: { fontSize: '14px', fontWeight: 'bold', lineHeight: 'normal' },
   },
   body: {
-    l: { fontSize: '18px', fontWeight: 'normal' },
-    m: { fontSize: '16px', fontWeight: 'normal' },
-    s: { fontSize: '14px', fontWeight: 'normal' },
+    l: { fontSize: '16px', fontWeight: 'normal', lineHeight: 'normal' },
+    m: { fontSize: '14px', fontWeight: 'normal', lineHeight: 'normal' },
+    s: { fontSize: '12px', fontWeight: 'normal', lineHeight: 'normal' },
   },
 } as const;
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -21,6 +21,7 @@ const theme = createTheme({
       secondary: color.gray200,
       tertiary: color.gray300,
       quaternary: color.gray500,
+      quinary: color.gray100,
       inverse: color.gray100,
       interactive: color.blue300,
     },
@@ -43,6 +44,12 @@ const theme = createTheme({
       opa100: color.gray500a,
       opa200: color.gray700a,
     },
+    icon: {
+      primary: color.gray600,
+      secondary: color.gray800,
+      tertiary: color.gray900,
+      inverse: color.gray0,
+    },
   },
   radius,
   typo: typography,
@@ -64,6 +71,28 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           fontFamily: typography.fontFamily.Pretendard,
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        root: {
+          fontFamily: typography.fontFamily.Pretendard,
+        },
+      },
+    },
+    MuiList: {
+      styleOverrides: {
+        root: {
+          backgroundColor: color.gray400,
+        },
+      },
+    },
+    MuiMenuItem: {
+      styleOverrides: {
+        root: {
+          fontFamily: typography.fontFamily.Pretendard,
+          backgroundColor: color.gray400,
         },
       },
     },

--- a/src/types/funnel/onboarding.type.ts
+++ b/src/types/funnel/onboarding.type.ts
@@ -6,16 +6,21 @@ export type Jobs = {
 };
 
 export type Infos = {
+  // 필수 속성
   hope_job: string;
+  education: string;
+  age: string;
   skills: string;
   experience: string;
-  others_experience: string;
+  hope_location: string;
+  profile_img: File | string;
   cover_letter: string;
-  location?: string; // 추가 가능
-  company?: string; // 추가 가능
-  culture?: string; // 추가 가능
-  purpose?: string; // 추가 가능
+  // 선택 속성
+  others_experience?: string;
   salary?: string;
+  company?: string;
+  culture?: string;
+  purpose?: string;
 };
 
 // 1. 아무것도 입력 안됨

--- a/src/utils/schemas/onboarding-schema.ts
+++ b/src/utils/schemas/onboarding-schema.ts
@@ -30,15 +30,37 @@ export const MoreInfoSchema = z.object({
   interested_list: InterestedSchema.shape.interested_list,
   work: WorkSchema.shape.work,
   info: z.object({
-    hope_job: z.string().min(1, '희망하는 직업을 선택해주세요.'),
+    hope_job: z.string().min(1, '희망하는 직무를 선택해주세요.'),
+    education: z.string().min(1, '학력을 선택해주세요.'),
+    age: z.string().min(1, '연령대를 선택해 주세요.'),
     skills: z.string().min(1, '보유한 기술을 입력해주세요.'),
-    experience: z.string().min(1, '경력을 입력해주세요.'),
-    others_experience: z.string().optional(),
+    experience: z.string().min(1, '경력을 선택해주세요.'),
+    hope_location: z.string().min(1, '희망하는 근무 지역을 선택해주세요.'),
+    profile_img: z
+      .any()
+      .refine((file: File) => !file.name, '증명 사진을 넣어주세요.')
+      .refine(
+        (file) => file.size < 5000000,
+        '사진의 사이즈는 5MB를 넘어갈 수 없습니다..',
+      )
+      .refine(
+        (file) => checkFileType(file),
+        '사진은 jpg, jepg, png 형식만 등록 가능합니다.',
+      ),
     cover_letter: z.string().min(10, '자기소개서를 10자 이상 입력해주세요.'),
-    location: z.string().optional(),
+    others_experience: z.string().optional(),
+    salary: z.string().optional(),
     company: z.string().optional(),
     culture: z.string().optional(),
     purpose: z.string().optional(),
-    salary: z.string().optional(),
   }),
 });
+
+function checkFileType(file: File) {
+  if (file?.name) {
+    const fileType = file.name.split('.').pop();
+    if (fileType === 'jpg' || fileType === 'png' || fileType === 'jpeg')
+      return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## 🚀 반영 브랜치

`style/onboarding` → `dev`


<br/>

## ✅ 작업 내용

- theme.ts icon 변수 추가
- 온보딩에서 사용하는 공통 Box 컴포넌트 스타일링 수정
- 각 퍼널 페이지 스타일링 수정
- figma foundation, variable 적용

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/53efcf24-5415-4e13-a775-08a0436f7eca)
![image](https://github.com/user-attachments/assets/d8f7641d-7803-4863-a393-7cfcdd06445b)
![image](https://github.com/user-attachments/assets/3ca2707d-3d92-40cf-ae48-be165ab9c013)
![image](https://github.com/user-attachments/assets/95ada3a0-944d-4900-ba08-b9149241e8c1)


<br/>

## ✏️ 앞으로의 과제

- 온보딩 페이지 헤더 구현