### PR TITLE
feat(components/adminpage): 관리자 페이지 초기 화면 구현

### DIFF
--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,61 +1,64 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { AppBar, Toolbar, Typography } from '@mui/material';
-import { styled } from '@mui/system';
-
-const Logo = styled(Typography)`
-  flex-grow: 1;
-  background-color: transparent;
-  padding: 5px 10px;
-`;
-
-const NavLink = styled(Link, {
-  shouldForwardProp: (prop) => prop !== 'active',
-})<{ active?: boolean }>(({ theme, active }) => ({
-  color: theme.palette.text.primary,
-  textDecoration: 'none',
-  position: 'relative',
-  padding: '8px 16px',
-  borderRadius: '4px',
-  '&:hover': {
-    textDecoration: 'underline',
-  },
-  ...(active && {
-    fontWeight: 'bold',
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: -2,
-      left: 0,
-      width: '100%',
-      height: 2,
-      backgroundColor: 'black',
-    },
-    '&:hover': {
-      textDecoration: 'none',
-    },
-  }),
-}));
-
-const LogoutButton = styled('button')(({ theme }) => ({
-  color: theme.palette.text.primary,
-  background: 'none',
-  border: 'none',
-  cursor: 'pointer',
-  padding: '8px 16px',
-  fontSize: '1rem',
-  '&:hover': {
-    textDecoration: 'underline',
-  },
-}));
+import { AppBar, Toolbar, Typography, Box } from '@mui/material';
+import { css, useTheme } from '@mui/material'; // 여기를 수정했습니다
 
 const Header = () => {
+  const theme = useTheme();
   const location = useLocation();
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    //TODO: 로그아웃 로직
+    // TODO: 로그아웃 로직
     navigate('/role-selection');
   };
+
+  const logoStyle = css`
+    flex-grow: 1;
+    background-color: transparent;
+    padding: 5px 10px;
+    font-size: 1.25rem;
+    font-weight: bold;
+    color: ${theme.palette.text.primary};
+  `;
+
+  const navLinkStyle = (active: boolean) => css`
+    color: ${theme.palette.text.primary};
+    text-decoration: none;
+    position: relative;
+    padding: 8px 16px;
+    border-radius: 4px;
+    &:hover {
+      text-decoration: underline;
+    }
+    ${active &&
+    `
+      font-weight: bold;
+      &::after {
+        content: "";
+        position: absolute;
+        bottom: -2px;
+        left: 0;
+        width: 100%;
+        height: 2px;
+        background-color: white;
+      }
+      &:hover {
+        text-decoration: none;
+      }
+    `}
+  `;
+
+  const logoutButtonStyle = css`
+    color: ${theme.palette.text.primary};
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px 16px;
+    font-size: 1rem;
+    &:hover {
+      text-decoration: underline;
+    }
+  `;
 
   return (
     <AppBar
@@ -67,16 +70,20 @@ const Header = () => {
       }}
     >
       <Toolbar>
-        <Logo variant="h6">F'LINK</Logo>
-        <NavLink
-          to="/dashboard"
-          active={location.pathname === '/admin'}
-        >
-          대시보드
-        </NavLink>
-        <LogoutButton onClick={handleLogout}>
-          로그아웃
-        </LogoutButton>
+        <Typography variant="h6" css={logoStyle}>
+          F'LINK
+        </Typography>
+        <Box>
+          <Link
+            to="/admin"
+            css={navLinkStyle(location.pathname === '/admin')}
+          >
+            대시보드
+          </Link>
+          <button css={logoutButtonStyle} onClick={handleLogout}>
+            로그아웃
+          </button>
+        </Box>
       </Toolbar>
     </AppBar>
   );

--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { AppBar, Toolbar, Typography, Box } from '@mui/material';
-import { css, useTheme } from '@mui/material'; // 여기를 수정했습니다
+import { css, useTheme } from '@mui/material';
 
 const Header = () => {
   const theme = useTheme();

--- a/src/components/AdminPage/BoothParticipation.tsx
+++ b/src/components/AdminPage/BoothParticipation.tsx
@@ -1,0 +1,60 @@
+import { Box, Typography, Paper } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+const BoothParticipation = () => {
+    const { palette, typography, radius } = useTheme();
+    return (
+        <Box>
+            <Typography 
+                variant="subtitle1" 
+                fontWeight="bold" 
+                mb={1}
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                `}
+            >
+                부스 참여 현황
+            </Typography>
+            <Paper
+                css={css`
+                    text-align: center;
+                    color: ${palette.text.secondary};
+                    border-radius: ${radius.sm}px;
+                    background-color: ${palette.background.inverse};
+                    padding: 50px;
+                    border: ${palette.divider_custom.primary};
+                `}
+            >
+                <AddIcon 
+                    css={css`
+                        font-size: 40px;
+                        color: ${palette.text.secondary};
+                        margin-bottom: 16px;
+                    `}
+                />
+                <Typography 
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                    `}
+                >
+                    등록된 부스가 없습니다.
+                </Typography>
+                <Typography 
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                    `}
+                >
+                    컨퍼런스 등록 후 확인 가능합니다.
+                </Typography>
+            </Paper>
+        </Box>
+    );
+};
+
+export default BoothParticipation;

--- a/src/components/AdminPage/GradeRankingCard.tsx
+++ b/src/components/AdminPage/GradeRankingCard.tsx
@@ -1,0 +1,59 @@
+import { Box, Typography, Paper } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+const GradeRankingCard = () => {
+    const { palette, typography, radius } = useTheme();
+    return (
+        <Box>
+            <Typography
+                variant="subtitle1"
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                    font-size: 16px;
+                    font-weight: bold;
+                    margin-bottom: 8px;
+                    text-align: left;
+                `}
+            >
+                등급별 참가자 랭킹
+            </Typography>
+            <Paper
+                css={css`
+                    background-color: ${palette.background.inverse};
+                    border-radius: ${radius.sm}px;
+                    padding: 16px;
+                    text-align: center;
+                    width: 274px;
+                    height: 294px;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    align-items: center;
+                `}
+            >
+                <AddIcon 
+                    css={css`
+                        font-size: 40px;
+                        color: ${palette.text.secondary};
+                        margin-bottom: 16px;
+                    `}
+                />
+                <Typography
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                        font-size: 14px;
+                        font-weight: 400;
+                    `}
+                >
+                    컨퍼런스 등록 후 확인 가능합니다.
+                </Typography>
+            </Paper>
+        </Box>
+    );
+};
+
+export default GradeRankingCard;

--- a/src/components/AdminPage/Modal/ConferenceModal.tsx
+++ b/src/components/AdminPage/Modal/ConferenceModal.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Box, TextField, Select, MenuItem, Button, Typography } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+
+interface ConferenceModalProps {
+    onClose: () => void;
+    onRegister: () => void;
+}
+
+const ConferenceModal: React.FC<ConferenceModalProps> = ({ onClose, onRegister }) => {
+    const { palette, typography, radius } = useTheme();
+
+    const modalStyle = css`
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 400px;
+        max-height: 70vh;
+        height: auto;
+        background-color: ${palette.background.secondary};
+        border-radius: ${radius.sm}px;
+        box-shadow: 24px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        overflow-y: auto;
+    `;
+
+    return (
+        <Box css={modalStyle}>
+            <Typography id="modal-modal-title" variant="h6" component="h2"
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                    font-weight: bold;
+                    text-align: center;
+                    margin-bottom: 20px;
+                `}
+            >
+                컨퍼런스 등록
+            </Typography>
+            <TextField label="컨퍼런스 명" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="컨퍼런스 주최자" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="시작일" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="시작 시간" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="종료일" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="종료 시간" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <TextField label="컨퍼런스 장소" variant="outlined" fullWidth margin="normal"
+                InputProps={{
+                    style: {
+                        color: palette.text.primary,
+                        fontFamily: typography.fontFamily,
+                    },
+                }}
+            />
+            <Select
+                fullWidth
+                margin="dense"
+                defaultValue=""
+                displayEmpty
+                inputProps={{ 'aria-label': 'Without label' }}
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                `}
+            >
+                <MenuItem value="" disabled>
+                    컨퍼런스 위치 선택
+                </MenuItem>
+            </Select>
+            <Select
+                fullWidth
+                margin="dense"
+                defaultValue=""
+                displayEmpty
+                inputProps={{ 'aria-label': 'Without label' }}
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                `}
+            >
+                <MenuItem value="" disabled>
+                    컨퍼런스 유형 선택
+                </MenuItem>
+            </Select>
+            <Button variant="contained" fullWidth
+                css={css`
+                    background-color: ${palette.background.primary};
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                    font-weight: bold;
+                    padding: 12px;
+                    &:hover {
+                        background-color: ${palette.background.tertiary};
+                    }
+                `}
+                onClick={() => {
+                    onRegister();
+                    onClose();
+                }}
+            >
+                등록하기
+            </Button>
+        </Box>
+    );
+};
+
+export default ConferenceModal;

--- a/src/components/AdminPage/PointRankingCard.tsx
+++ b/src/components/AdminPage/PointRankingCard.tsx
@@ -1,0 +1,59 @@
+import { Box, Typography, Paper } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+const PointRankingCard = () => {
+    const { palette, typography, radius } = useTheme();
+    return (
+        <Box>
+            <Typography
+                variant="subtitle1"
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                    font-size: 16px;
+                    font-weight: bold;
+                    margin-bottom: 8px;
+                    text-align: left;
+                `}
+            >
+                누적 포인트 랭킹
+            </Typography>
+            <Paper
+                css={css`
+                    background-color: ${palette.background.inverse};
+                    border-radius: ${radius.sm}px;
+                    padding: 16px;
+                    text-align: center;
+                    width: 274px;
+                    height: 294px;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                    align-items: center;
+                `}
+            >
+                <AddIcon 
+                    css={css`
+                        font-size: 40px;
+                        color: ${palette.text.secondary};
+                        margin-bottom: 16px;
+                    `}
+                />
+                <Typography
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                        font-size: 14px;
+                        font-weight: 400;
+                    `}
+                >
+                    컨퍼런스 등록 후 확인 가능합니다.
+                </Typography>
+            </Paper>
+        </Box>
+    );
+};
+
+export default PointRankingCard;

--- a/src/components/AdminPage/RegButtons.tsx
+++ b/src/components/AdminPage/RegButtons.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Box, Button, Modal, Typography } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import ConferenceModal from './Modal/ConferenceModal';
+
+const ConferenceRegistration = () => {
+  const { palette, typography, radius } = useTheme();
+  const [isConferenceRegistered, setIsConferenceRegistered] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const handleRegister = () => {
+    handleOpen(); // 모달 열기
+  };
+
+  const handleModify = () => {
+    if (isConferenceRegistered) {
+      // TODO: 컨퍼런스 수정 로직
+    }
+  };
+
+  const handleModalRegister = () => {
+    setIsConferenceRegistered(true);
+    handleClose();
+  };
+
+  const buttonStyle = css`
+    color: ${palette.text.primary};
+    border: 1px solid ${palette.border.primary};
+    border-radius: ${radius.md}px;
+    padding: 12px 14px;
+    font-family: ${typography.fontFamily};
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    flex: 1 0 0;
+    background-color: ${palette.background.primary};
+  `;
+
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      gap="16px"
+      paddingTop="24px"
+    >
+      <Button
+        variant="outlined"
+        css={buttonStyle}
+        onClick={handleRegister}
+      >
+        <AddIcon 
+          css={css`
+            font-size: 20px;
+          `}
+        />
+        <Typography
+          variant="body2"
+          css={css`
+            font-family: ${typography.fontFamily};
+            font-weight: 500;
+          `}
+        >
+          컨퍼런스 등록
+        </Typography>
+      </Button>
+      <Button
+        variant="outlined"
+        css={css`
+          ${buttonStyle}
+          opacity: ${isConferenceRegistered ? 1 : 0.5};
+          cursor: ${isConferenceRegistered ? 'pointer' : 'not-allowed'};
+        `}
+        onClick={handleModify}
+      >
+        <EditIcon 
+          css={css`
+            font-size: 20px;
+          `}
+        />
+        <Typography
+          variant="body2"
+          css={css`
+            font-family: ${typography.fontFamily};
+            font-weight: 500;
+          `}
+        >
+          컨퍼런스 수정
+        </Typography>
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <ConferenceModal onClose={handleClose} onRegister={handleModalRegister} />
+      </Modal>
+    </Box>
+  );
+};
+
+export default ConferenceRegistration;

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -1,0 +1,60 @@
+import { Box, Typography, Paper } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+
+const SessionParticipation = () => {
+    const { palette, typography, radius } = useTheme();
+    return (
+        <Box>
+            <Typography 
+                variant="subtitle1" 
+                fontWeight="bold" 
+                mb={1}
+                css={css`
+                    color: ${palette.text.primary};
+                    font-family: ${typography.fontFamily};
+                `}
+            >
+                세션 참여 현황
+            </Typography>
+            <Paper
+                css={css`
+                    text-align: center;
+                    color: ${palette.text.secondary};
+                    border-radius: ${radius.sm}px;
+                    background-color: ${palette.background.inverse};
+                    padding: 50px;
+                    border: ${palette.divider_custom.primary};
+                `}
+            >
+                <AddIcon 
+                    css={css`
+                        font-size: 40px;
+                        color: ${palette.text.secondary};
+                        margin-bottom: 16px;
+                    `}
+                />
+                <Typography 
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                    `}
+                >
+                    등록된 세션이 없습니다.
+                </Typography>
+                <Typography 
+                    variant="body2"
+                    css={css`
+                        color: ${palette.text.secondary};
+                        font-family: ${typography.fontFamily};
+                    `}
+                >
+                    컨퍼런스 등록 후 확인 가능합니다.
+                </Typography>
+            </Paper>
+        </Box>
+    );
+};
+
+export default SessionParticipation;

--- a/src/components/AdminPage/UserCount.tsx
+++ b/src/components/AdminPage/UserCount.tsx
@@ -1,0 +1,116 @@
+import { Box, Typography, Paper } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import { useState, useEffect } from 'react';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+
+const UserCount = ({ title, count }: { title: string; count?: number | string }) => {
+    const theme = useTheme();
+    
+    return (
+        <Paper
+            css={css`
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                color: ${theme.palette.text.primary};
+                border-radius: ${theme.radius.md}px;
+                background-color: transparent;
+                border: 1px solid ${theme.palette.border.primary};
+                overflow: hidden;
+                width: 260px;
+                height: 50px;
+            `}
+        >
+            <Box
+                css={css`
+                    display: flex;
+                    align-items: center;
+                    padding-left: 12px;
+                `}
+            >
+                <PeopleAltIcon sx={{ color: theme.palette.text.quaternary }} />
+            </Box>
+            <Box
+                css={css`
+                    flex-grow: 1;
+                    padding: 14px 12px;
+                `}
+            >
+                <Typography
+                    variant="body1"
+                    css={css`
+                        color: ${theme.palette.text.quaternary};
+                        font-family: ${theme.typography.fontFamily};
+                        font-size: 14px;
+                        font-weight: 400;
+                        line-height: normal;
+                        overflow: hidden;
+                    `}
+                >
+                    {title}
+                </Typography>
+                
+                <Typography
+                    variant="h6"
+                    css={css`
+                        color: #F5F5F5;
+                        font-family: ${theme.typography.fontFamily};
+                        font-size: 18px;
+                        font-style: normal;
+                        font-weight: 700;
+                        line-height: normal;
+                    `}
+                >
+                    {count ?? '정보 없음'}
+                </Typography>
+            </Box>
+        </Paper>
+    );
+};
+
+const UserCounts = () => {
+    const [counts, setCounts] = useState<{
+        sessionCount: number | undefined;
+        boothCount: number | undefined;
+        eventCount: number | undefined;
+        serviceCount: number | undefined;
+    }>({
+        sessionCount: undefined,
+        boothCount: undefined,
+        eventCount: undefined,
+        serviceCount: undefined,
+    });
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                setCounts({
+                    sessionCount: 100,
+                    boothCount: 200,
+                    eventCount: 300,
+                    serviceCount: 400,
+                });
+            } catch (error) {
+                console.error('Failed to fetch user counts:', error);
+            }
+        };
+        fetchData();
+    }, []);
+
+    return (
+        <Box
+            display="grid"
+            gridTemplateColumns="repeat(2, auto)"
+            gap="12px 41px"
+            padding={2}
+            justifyContent="center"
+        >
+            <UserCount title="세션 참여자 수" count={counts.sessionCount} />
+            <UserCount title="부스 참여자 수" count={counts.boothCount} />
+            <UserCount title="행사 참가자 수" count={counts.eventCount} />
+            <UserCount title="서비스 가입자 수" count={counts.serviceCount} />
+        </Box>
+    );
+};
+
+export default UserCounts;

--- a/src/routes/layouts/Admin.tsx
+++ b/src/routes/layouts/Admin.tsx
@@ -1,7 +1,13 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
-import { css, useTheme } from '@mui/material';
-
+import { css, useTheme, Box } from '@mui/material';
 import Header from '@components/AdminHeader';
+import UserCounts from '@components/AdminPage/UserCount';
+import SessionParticipation from '@components/AdminPage/SessionParticipation';
+import BoothParticipation from '@components/AdminPage/BoothParticipation';
+import GradeRankingCard from '@components/AdminPage/GradeRankingCard';
+import PointRankingCard from '@components/AdminPage/PointRankingCard';
+import ConferenceRegistration from '@components/AdminPage/RegButtons';
+
 const AdminLayout = () => {
   const { palette } = useTheme();
   return (
@@ -20,6 +26,20 @@ const AdminLayout = () => {
       `}
     >
       <Header />
+      <UserCounts />
+      <SessionParticipation />
+      <BoothParticipation />
+      <Box
+        css={css`
+          display: flex;
+          justify-content: space-between; 
+          gap: 1rem; 
+        `}
+      >
+        <GradeRankingCard />
+        <PointRankingCard />
+      </Box>
+      <ConferenceRegistration />
       <Outlet />
       <ScrollRestoration />
     </div>


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/#24_관리자페이지` → `dev`

<br/>

## ✅ 작업 내용

- 관리자 페이지  각 컴포넌트 구현
- 스타일링 적용
- 기능은 간단하게 컨퍼런스 등록 버튼 클릭 시 모달 표시, 컨퍼런스 등록 후 수정 버튼 활성화만 구현해둔 상태

<br/>

## 🌠 이미지 첨부
<img width="1508" alt="스크린샷 2025-03-12 오후 5 51 26" src="https://github.com/user-attachments/assets/4e623bfc-4960-4c2e-8604-a76dae8c5438" />

<img width="1508" alt="스크린샷 2025-03-12 오후 5 51 40" src="https://github.com/user-attachments/assets/187788fe-17ab-4e45-8118-36ceaccf936d" />

<br/>

## ✏️ 앞으로의 과제

- 로그인 스타일 수정

<br/>

## 📌 이슈 링크

- #24 
