### PR TITLE
fix(admin): 참여자, 랭킹 컴포넌트 오버플로우 해결

### DIFF
--- a/src/components/AdminPage/GradeRankingCard.tsx
+++ b/src/components/AdminPage/GradeRankingCard.tsx
@@ -5,7 +5,13 @@ import AddIcon from '@mui/icons-material/Add';
 const GradeRankingCard = () => {
     const { palette, typography, radius } = useTheme();
     return (
-        <Box>
+        <Box
+            css={css`
+                width: 100%;
+                max-width: 300px; // 최대 너비 설정
+                margin: 0 auto; // 중앙 정렬
+            `}
+        >
             <Typography
                 variant="subtitle1"
                 css={css`
@@ -25,8 +31,8 @@ const GradeRankingCard = () => {
                     border-radius: ${radius.sm}px;
                     padding: 16px;
                     text-align: center;
-                    width: 274px;
-                    height: 294px;
+                    width: 100%; // 부모 요소의 너비에 맞춤
+                    aspect-ratio: 1 / 1; // 정사각형 비율 유지
                     display: flex;
                     flex-direction: column;
                     justify-content: center;

--- a/src/components/AdminPage/Modal/ConferenceModal.tsx
+++ b/src/components/AdminPage/Modal/ConferenceModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, TextField, Select, MenuItem, Button, Typography } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 
@@ -7,7 +6,42 @@ interface ConferenceModalProps {
     onRegister: () => void;
 }
 
-const ConferenceModal: React.FC<ConferenceModalProps> = ({ onClose, onRegister }) => {
+const InputField = ({ label, placeholder }: { label: string; placeholder: string }) => {
+    const { palette } = useTheme();
+    
+    return (
+        <>
+            <Typography
+                css={css`
+                    color: ${palette.text.primary};
+                    margin-bottom: 0;
+                `}
+            >
+                {label}
+            </Typography>
+            <TextField
+                variant="outlined"
+                fullWidth
+                placeholder={placeholder}
+                sx={{
+                    '& .MuiOutlinedInput-root': {
+                        '& fieldset': {
+                            borderColor: palette.border.secondary,
+                        },
+                        '&:hover fieldset': {
+                            borderColor: palette.border.secondary,
+                        },
+                        '&.Mui-focused fieldset': {
+                            borderColor: palette.border.secondary,
+                        },
+                    },
+                }}
+            />
+        </>
+    );
+};
+
+const ConferenceModal = ({ onClose, onRegister }: ConferenceModalProps) => {
     const { palette, typography, radius } = useTheme();
 
     const modalStyle = css`
@@ -15,7 +49,7 @@ const ConferenceModal: React.FC<ConferenceModalProps> = ({ onClose, onRegister }
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        width: 400px;
+        width: 350px;
         max-height: 70vh;
         height: auto;
         background-color: ${palette.background.secondary};
@@ -35,96 +69,63 @@ const ConferenceModal: React.FC<ConferenceModalProps> = ({ onClose, onRegister }
                     color: ${palette.text.primary};
                     font-family: ${typography.fontFamily};
                     font-weight: bold;
-                    text-align: center;
-                    margin-bottom: 20px;
+                    text-align: left;
+                    margin-bottom: 10px;
                 `}
             >
                 컨퍼런스 등록
             </Typography>
-            <TextField label="컨퍼런스 명" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="컨퍼런스 주최자" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="시작일" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="시작 시간" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="종료일" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="종료 시간" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
-            <TextField label="컨퍼런스 장소" variant="outlined" fullWidth margin="normal"
-                InputProps={{
-                    style: {
-                        color: palette.text.primary,
-                        fontFamily: typography.fontFamily,
-                    },
-                }}
-            />
+            <InputField label="컨퍼런스 명" placeholder="컨퍼런스 명 입력" />
+            <InputField label="컨퍼런스 주최자" placeholder="컨퍼런스 주최자 입력" />
+            <InputField label="시작일" placeholder="시작일 입력" />
+            <InputField label="시작 시간" placeholder="시작 시간 입력" />
+            <InputField label="종료일" placeholder="종료일 입력" />
+            <InputField label="종료 시간" placeholder="종료 시간 입력" />
+            <InputField label="컨퍼런스 장소" placeholder="컨퍼런스 장소 입력" />
+            <Typography css={css` color: ${palette.text.primary}; `}>컨퍼런스 위치 선택</Typography>
             <Select
                 fullWidth
                 margin="dense"
                 defaultValue=""
                 displayEmpty
-                inputProps={{ 'aria-label': 'Without label' }}
-                css={css`
-                    color: ${palette.text.primary};
-                    font-family: ${typography.fontFamily};
-                `}
+                sx={{
+                    '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    color: palette.text.quaternary,
+                }}
             >
                 <MenuItem value="" disabled>
-                    컨퍼런스 위치 선택
+                    선택
                 </MenuItem>
             </Select>
+            <Typography css={css` color: ${palette.text.primary}; `}>컨퍼런스 유형 선택</Typography>
             <Select
                 fullWidth
                 margin="dense"
                 defaultValue=""
                 displayEmpty
-                inputProps={{ 'aria-label': 'Without label' }}
-                css={css`
-                    color: ${palette.text.primary};
-                    font-family: ${typography.fontFamily};
-                `}
+                sx={{
+                    '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    '&:hover .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                        borderColor: palette.border.secondary,
+                    },
+                    color: palette.text.quaternary,
+                }}
             >
                 <MenuItem value="" disabled>
-                    컨퍼런스 유형 선택
+                    선택
                 </MenuItem>
             </Select>
             <Button variant="contained" fullWidth
@@ -134,6 +135,7 @@ const ConferenceModal: React.FC<ConferenceModalProps> = ({ onClose, onRegister }
                     font-family: ${typography.fontFamily};
                     font-weight: bold;
                     padding: 12px;
+                    border: none;
                     &:hover {
                         background-color: ${palette.background.tertiary};
                     }

--- a/src/components/AdminPage/PointRankingCard.tsx
+++ b/src/components/AdminPage/PointRankingCard.tsx
@@ -2,10 +2,16 @@ import { Box, Typography, Paper } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 
-const PointRankingCard = () => {
+const GradeRankingCard = () => {
     const { palette, typography, radius } = useTheme();
     return (
-        <Box>
+        <Box
+            css={css`
+                width: 100%;
+                max-width: 300px;
+                margin: 0 auto;
+            `}
+        >
             <Typography
                 variant="subtitle1"
                 css={css`
@@ -25,8 +31,8 @@ const PointRankingCard = () => {
                     border-radius: ${radius.sm}px;
                     padding: 16px;
                     text-align: center;
-                    width: 274px;
-                    height: 294px;
+                    width: 100%;
+                    aspect-ratio: 1 / 1;
                     display: flex;
                     flex-direction: column;
                     justify-content: center;
@@ -56,4 +62,4 @@ const PointRankingCard = () => {
     );
 };
 
-export default PointRankingCard;
+export default GradeRankingCard;

--- a/src/components/AdminPage/RegButtons.tsx
+++ b/src/components/AdminPage/RegButtons.tsx
@@ -99,6 +99,7 @@ const ConferenceRegistration = () => {
         onClose={handleClose}
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
+        disableEnforceFocus
       >
         <ConferenceModal onClose={handleClose} onRegister={handleModalRegister} />
       </Modal>

--- a/src/components/AdminPage/UserCount.tsx
+++ b/src/components/AdminPage/UserCount.tsx
@@ -5,7 +5,7 @@ import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
 
 const UserCount = ({ title, count }: { title: string; count?: number | string }) => {
     const theme = useTheme();
-    
+
     return (
         <Paper
             css={css`
@@ -17,8 +17,8 @@ const UserCount = ({ title, count }: { title: string; count?: number | string })
                 background-color: transparent;
                 border: 1px solid ${theme.palette.border.primary};
                 overflow: hidden;
-                width: 260px;
-                height: 50px;
+                width: 100%;
+                height: 60px;
             `}
         >
             <Box
@@ -45,6 +45,7 @@ const UserCount = ({ title, count }: { title: string; count?: number | string })
                         font-weight: 400;
                         line-height: normal;
                         overflow: hidden;
+                        white-space: nowrap;
                     `}
                 >
                     {title}
@@ -70,10 +71,10 @@ const UserCount = ({ title, count }: { title: string; count?: number | string })
 
 const UserCounts = () => {
     const [counts, setCounts] = useState<{
-        sessionCount: number | undefined;
-        boothCount: number | undefined;
-        eventCount: number | undefined;
-        serviceCount: number | undefined;
+        sessionCount?: number;
+        boothCount?: number;
+        eventCount?: number;
+        serviceCount?: number;
     }>({
         sessionCount: undefined,
         boothCount: undefined,
@@ -99,11 +100,12 @@ const UserCounts = () => {
 
     return (
         <Box
-            display="grid"
-            gridTemplateColumns="repeat(2, auto)"
-            gap="12px 41px"
-            padding={2}
-            justifyContent="center"
+            css={css`
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+                gap: 16px;
+                padding: 5px;
+            `}
         >
             <UserCount title="세션 참여자 수" count={counts.sessionCount} />
             <UserCount title="부스 참여자 수" count={counts.boothCount} />


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/관리자_오버플로우` → `dev`
<br/>

## ✅ 작업 내용

- 참여자 수, 랭킹 컴포넌트가 모바일에서 오버플로우 발생
- 모달 창 aria-hidden 오류 해결
- 모달 스타일 수정

<br/>

## 🌠 이미지 첨부
<img width="194" alt="스크린샷 2025-03-13 오후 1 03 11" src="https://github.com/user-attachments/assets/4c7762db-1ce9-4981-9d3c-be8965ce5aea" />

<img width="194" alt="스크린샷 2025-03-13 오후 2 32 04" src="https://github.com/user-attachments/assets/3a645cd0-2547-44a9-9174-649c015bda18" />
