### PR TITLE
feat(session, booth): 세션, 부스 참여 현황 페이지 구현

### DIFF
--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,10 +1,11 @@
-import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { AppBar, Toolbar, Typography, Box } from '@mui/material';
-import { css, useTheme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, Button } from '@mui/material';
+import { css, useTheme } from '@mui/material/styles';
+import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
+import { typography } from '@styles/foundation';
 
 const Header = () => {
   const theme = useTheme();
-  const location = useLocation();
   const navigate = useNavigate();
 
   const handleLogout = () => {
@@ -12,80 +13,48 @@ const Header = () => {
     navigate('/role-selection');
   };
 
-  const logoStyle = css`
-    flex-grow: 1;
-    background-color: transparent;
-    padding: 5px 10px;
-    font-size: 1.25rem;
-    font-weight: bold;
-    color: ${theme.palette.text.primary};
+  const headerStyle = css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: ${theme.spacing(2)} 0;
   `;
 
-  const navLinkStyle = (active: boolean) => css`
+  const logoStyle = css`
+    font-weight: 800;
+    font-size: 28px;
+    font-family: ${typography.fontFamily.Montserrat};
     color: ${theme.palette.text.primary};
-    text-decoration: none;
-    position: relative;
-    padding: 8px 16px;
-    border-radius: 4px;
-    &:hover {
-      text-decoration: underline;
-    }
-    ${active &&
-    `
-      font-weight: bold;
-      &::after {
-        content: "";
-        position: absolute;
-        bottom: -2px;
-        left: 0;
-        width: 100%;
-        height: 2px;
-        background-color: white;
-      }
-      &:hover {
-        text-decoration: none;
-      }
-    `}
   `;
 
   const logoutButtonStyle = css`
+    background-color: ${theme.palette.background.quaternary};
     color: ${theme.palette.text.primary};
-    background: none;
-    border: none;
-    cursor: pointer;
+    border-radius: 18px;
     padding: 8px 16px;
-    font-size: 1rem;
-    &:hover {
-      text-decoration: underline;
+    border: none;
+    .MuiSvgIcon-root {
+      color: ${theme.palette.icon.tertiary};
     }
   `;
 
   return (
-    <AppBar
-      position="static"
-      elevation={0}
-      sx={{
-        backgroundColor: 'transparent',
-        boxShadow: 'none',
-      }}
-    >
-      <Toolbar>
-        <Typography variant="h6" css={logoStyle}>
-          F'LINK
-        </Typography>
-        <Box>
-          <Link
-            to="/admin"
-            css={navLinkStyle(location.pathname === '/admin')}
-          >
-            대시보드
-          </Link>
-          <button css={logoutButtonStyle} onClick={handleLogout}>
-            로그아웃
-          </button>
-        </Box>
-      </Toolbar>
-    </AppBar>
+    <Box component="header" css={headerStyle}>
+      <Typography variant="h6" css={logoStyle}>
+        Dashboard
+      </Typography>
+      <Button
+        variant="contained"
+        startIcon={<LogoutOutlinedIcon />}
+        onClick={handleLogout}
+        css={logoutButtonStyle}
+      >
+        로그아웃
+      </Button>
+    </Box>
   );
 };
 

--- a/src/components/AdminPage/BoothBox.tsx
+++ b/src/components/AdminPage/BoothBox.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import { css, useTheme } from '@mui/material/styles';
+import QrCodeIcon from '@mui/icons-material/QrCode';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+
+interface BoothBoxProps {
+  date: string;
+  place: string;
+  title: string;
+  category: string;
+  chartData?: any[];
+  onDelete: () => void;
+}
+
+const BoothBox = ({ date, place, title, category, onDelete }: BoothBoxProps) => {
+  const theme = useTheme();
+  const { palette, spacing, typo } = theme;
+  const [open, setOpen] = useState(false);
+
+  const boxStyle = css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background-color: ${palette.background.quaternary};
+    padding: ${spacing(2)}px;
+    border-radius: 18px;
+    margin-bottom: ${spacing(2)}px;
+    color: ${palette.text.primary};
+  `;
+
+  const infoStyle = css`
+    font-family: ${typo.fontFamily.Pretendard};
+    color: ${palette.text.primary};
+    margin-bottom: ${spacing(0.5)}px;
+  `;
+
+  const iconContainerStyle = css`
+    color: ${palette.icon.primary};
+    position: absolute;
+    top: 8px;           
+    right: 8px;        
+    display: flex;
+    gap: 2px;   
+  `;
+
+  return (
+    <Box css={boxStyle}>
+      <ConfirmDeleteDialog
+        open={open}
+        title="부스를 삭제하시겠습니까?"
+        description="부스 삭제 시 복구가 불가능합니다."
+        onClose={() => setOpen(false)}
+        onConfirm={() => {
+          onDelete();
+          setOpen(false);
+        }}
+      />
+      <Box css={iconContainerStyle}>
+        <IconButton size="small" color="inherit">
+          <QrCodeIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" color="inherit">
+          <EditIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      </Box>
+      
+      {/* 정보 영역 */}
+      <Typography css={infoStyle}>{date}  {place}</Typography>
+      <Typography css={infoStyle}>{title}  {category}</Typography>
+
+      {/* 차트 데이터 영역 */}
+      <Typography variant="body2"> !차트 데이터 표시 영역!</Typography>
+    </Box>
+  );
+};
+
+export default BoothBox;

--- a/src/components/AdminPage/SessionBox.tsx
+++ b/src/components/AdminPage/SessionBox.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
+import { css, useTheme } from '@mui/material/styles';
+import QrCodeIcon from '@mui/icons-material/QrCode';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+
+interface SessionBoxProps {
+  date: string;
+  place: string;
+  time: string;
+  title: string;
+  speaker: string;
+  chartData?: any[];
+  onDelete: () => void;
+}
+
+const SessionBox = ({ date, place, time, title, speaker, onDelete }: SessionBoxProps) => {
+  const theme = useTheme();
+  const { palette, spacing, typo } = theme;
+  const [open, setOpen] = useState(false);
+
+  const boxStyle = css`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background-color: ${palette.background.quaternary};
+    padding: ${spacing(2)}px;
+    border-radius: 18px;
+    margin-bottom: ${spacing(2)}px;
+    color: ${palette.text.primary};
+  `;
+
+  const infoStyle = css`
+    font-family: ${typo.fontFamily.Pretendard};
+    color: ${palette.text.primary};
+    margin-bottom: ${spacing(0.5)}px;
+  `;
+
+  const iconContainerStyle = css`
+    color: ${palette.icon.primary};
+    position: absolute;
+    top: 8px;           
+    right: 8px;        
+    display: flex;
+    gap: 2px;   
+  `;
+
+  return (
+    <Box css={boxStyle}>
+      <ConfirmDeleteDialog
+        open={open}
+        title="세션을 삭제하시겠습니까?"
+        description="세션 삭제 시 복구가 불가능합니다."
+        onClose={() => setOpen(false)}
+        onConfirm={() => {
+          onDelete();
+          setOpen(false);
+        }}
+      />
+      <Box css={iconContainerStyle}>
+        <IconButton size="small" color="inherit">
+          <QrCodeIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" color="inherit">
+          <EditIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      {/* 정보 영역 */}
+      <Typography css={infoStyle}>{date} {place}</Typography>
+      <Typography css={infoStyle}>{time}</Typography>
+      <Typography css={infoStyle}>{title} {speaker}</Typography>
+
+      {/* 차트 데이터 영역 */}
+      <Typography variant="body2"> !차트 데이터 표시 영역!</Typography>
+    </Box>
+  );
+};
+
+export default SessionBox;

--- a/src/components/ConfirmDeleteDialog.tsx
+++ b/src/components/ConfirmDeleteDialog.tsx
@@ -1,0 +1,79 @@
+import { Dialog, DialogActions, DialogContent, DialogTitle, Button, Typography } from '@mui/material';
+import { css, useTheme } from '@mui/material/styles';
+
+interface ConfirmDeleteDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmDeleteDialog = ({ open, title, description, onClose, onConfirm }: ConfirmDeleteDialogProps) => {
+  const theme = useTheme();
+  const { palette, spacing, typo } = theme;
+
+  const titleStyle = css`
+    font-family: ${typo.fontFamily.Pretendard};
+    font-size: 22px;
+    font-weight: 700;
+    text-align: center;
+  `;
+
+  const descriptionStyle = css`
+    text-align: center;
+    color: ${palette.text.secondary};
+  `;
+
+  const actionsStyle = css`
+    display: flex;
+    justify-content: center;
+    padding-bottom: ${spacing(2)}px;
+  `;
+
+  const buttonStyle = css`
+    border-radius: 12px;
+    height: 50px;
+    width: 160px;
+    flex: 1 0 0;
+  `;
+
+  const deleteButtonStyle = css`
+    ${buttonStyle}
+    background-color: ${palette.background.inverse};
+    color: ${palette.text.inverse};
+    border: none;
+  `;
+
+  const cancelButtonStyle = css`
+    ${buttonStyle}
+    background-color: ${palette.background.quinary};
+    color: ${palette.text.primary};
+    border: none;
+  `;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth
+    PaperProps={{
+        sx: {
+          backgroundColor: palette.background.quaternary,
+        },
+    }}
+    >
+      <DialogTitle css={titleStyle}>{title}</DialogTitle>
+      <DialogContent>
+        <Typography css={descriptionStyle}>{description}</Typography>
+      </DialogContent>
+      <DialogActions css={actionsStyle}>
+        <Button variant="contained" onClick={onConfirm} css={deleteButtonStyle}>
+          삭제하기
+        </Button>
+        <Button variant="contained" onClick={onClose} css={cancelButtonStyle}>
+          취소하기
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmDeleteDialog;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,6 +11,8 @@ import FindIdPage from './pages/FindIdPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import OnBoarding from './pages/OnBoarding';
 import DefaultNavLayout from './layouts/DefaultNav';
+import SessionDetail from './pages/SessionDetail';
+import BoothDetail from './pages/BoothDetail';
 
 const router = createBrowserRouter([
   {
@@ -69,6 +71,14 @@ const router = createBrowserRouter([
         path: '*',
         element: <NotFound />,
       },
+      {
+        path: '/sessionDetail',  /* 추후 뺄 예정 */
+        element: <SessionDetail />,
+      },
+      {
+        path: '/boothDetail',  /* 추후 뺄 예정 */
+        element: <BoothDetail />,
+      }
     ],
   },
   {

--- a/src/routes/pages/BoothDetail.tsx
+++ b/src/routes/pages/BoothDetail.tsx
@@ -1,0 +1,80 @@
+import { Typography, Box, Button } from '@mui/material';
+import Header from '@components/AdminHeader';
+import BoothBox from '@components/AdminPage/BoothBox';
+import { css, useTheme } from '@mui/material/styles';
+import { typography } from '@styles/foundation';
+import AddIcon from '@mui/icons-material/Add';
+
+const BoothDetail = () => {
+  const theme = useTheme();
+  const { palette, spacing } = theme;
+
+  const pageStyle = css`
+    display: flex;
+    flex-direction: column;
+    padding: ${spacing(2)};
+  `;
+
+  const titleStyle = css`
+    color: ${palette.text.primary};
+    font-family: ${typography.fontFamily.Pretendard};
+    font-size: 26px;
+    font-weight: bold;
+  `;
+
+  const registerButtonStyle = css`
+    background-color: transparent;
+    color: ${palette.text.quaternary};
+    border-color: ${palette.border.secondary};
+    border-radius: 18px;
+    padding: 8px 16px;
+    border: 1px solid ${palette.border.secondary};
+  `;
+
+  const BoothListStyle = css`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing(2)}px;
+  `;
+
+  const handleRegisterClick = () => {
+    //TODO: 부스 등록 모달 이동
+  };
+
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
+
+  return (
+    <Box css={pageStyle}>
+      <Header />
+      <Box display="flex" justifyContent="space-between" alignItems="center" mt={2} mb={2}>
+        <Typography variant="h4" css={titleStyle}>
+          부스 참여 현황
+        </Typography>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={handleRegisterClick}
+          css={registerButtonStyle}
+        >
+          부스 등록
+        </Button>
+      </Box>
+
+      {/* Booth List */}
+      <Box css={BoothListStyle} sx={{gap: 2}}>
+        {/* 예시 데이터 */}
+        <BoothBox
+          date="9/15"
+          place="부스 A"
+          title="DevWave"
+          category="AI"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default BoothDetail;

--- a/src/routes/pages/SessionDetail.tsx
+++ b/src/routes/pages/SessionDetail.tsx
@@ -1,0 +1,91 @@
+import { Typography, Box, Button } from '@mui/material';
+import Header from '@components/AdminHeader';
+import SessionBox from '@components/AdminPage/SessionBox';
+import { css, useTheme } from '@mui/material/styles';
+import { typography } from '@styles/foundation';
+import AddIcon from '@mui/icons-material/Add';
+
+const SessionDetail = () => {
+  const theme = useTheme();
+  const { palette, spacing } = theme;
+
+  const pageStyle = css`
+    display: flex;
+    flex-direction: column;
+    padding: ${spacing(2)};
+  `;
+
+  const titleStyle = css`
+    color: ${palette.text.primary};
+    font-family: ${typography.fontFamily.Pretendard};
+    font-size: 26px;
+    flex: 1;
+    font-weight: bold;
+  `;
+
+  const registerButtonStyle = css`
+    background-color: transparent;
+    color: ${palette.text.quaternary};
+    border-color: ${palette.border.secondary};
+    border-radius: 18px;
+    padding: 8px 16px;
+    border: 1px solid ${palette.border.secondary};
+  `;
+
+  const sessionListStyle = css`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing(2)}px;
+  `;
+
+  const handleRegisterClick = () => {
+    //TODO: 세션 등록 모달 이동
+  };
+
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
+
+  return (
+    <Box css={pageStyle}>
+      <Header />
+
+      <Box display="flex" justifyContent="space-between" alignItems="center" mt={2} mb={2}>
+        <Typography variant="h4" css={titleStyle}>
+          세션 참여 현황
+        </Typography>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={handleRegisterClick}
+          css={registerButtonStyle}
+        >
+          세션 등록
+        </Button>
+      </Box>
+
+      {/* Session List */}
+      <Box css={sessionListStyle} sx={{gap: 2}}>
+        <SessionBox
+          date="9/15"
+          place="세션 1-1"
+          title="최신 기술 동향"
+          time="10:30-11:30"
+          speaker="김지혁"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+        <SessionBox
+          date="9/15"
+          place="세션 1-2"
+          title="최신 기술 동향"
+          time="10:30-11:30"
+          speaker="홍길동"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default SessionDetail;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -22,7 +22,7 @@ const theme = createTheme({
       tertiary: color.gray300,
       quaternary: color.gray500,
       quinary: color.gray100,
-      inverse: color.gray100,
+      inverse: color.gray900,
       interactive: color.blue300,
     },
     border: {


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/sessionDetail` → `dev`
<br/>

## ✅ 작업 내용

- 세션, 부스 참여 현황 페이지 구현
- 일단 세션과 부스 각각 박스 컴포넌트 구현하였습니다. 안에 들어가는 정보 동일한게 날짜뿐이라서 복잡할까봐 두개로 나눴는데 동균님 생각하시기에 하나가 편하시면 수정하겠습니다!
- 세션, 부스 삭제 팝업 구현

<br/>

## 🌠 이미지 첨부

![스크린샷 2025-03-17 오후 5 39 50](https://github.com/user-attachments/assets/3eda7b87-bc80-4c99-bc3f-0af10b23c62c)
![스크린샷 2025-03-17 오후 5 40 04](https://github.com/user-attachments/assets/7aefb4e4-d4ee-4e4e-b88e-3b9ab534bc1a)
![스크린샷 2025-03-17 오후 5 40 30](https://github.com/user-attachments/assets/22db1ff1-ee4b-4683-a552-9f9239d18835)
![스크린샷 2025-03-17 오후 5 40 15](https://github.com/user-attachments/assets/392c9767-1abc-489e-a167-08c97b4caf9d)


<br/>

## ✏️ 앞으로의 과제

- 세션, 부스 등록

<br/>
