### PR TITLE
feat(admin-popup): 관리자 페이지 팝업 구현

### DIFF
--- a/src/components/AdminPage/BoothBox.tsx
+++ b/src/components/AdminPage/BoothBox.tsx
@@ -13,9 +13,10 @@ interface BoothBoxProps {
   category: string;
   chartData?: any[];
   onDelete: () => void;
+  onEdit: () => void;
 }
 
-const BoothBox = ({ date, place, title, category, onDelete }: BoothBoxProps) => {
+const BoothBox = ({ date, place, title, category, onDelete, onEdit }: BoothBoxProps) => {
   const theme = useTheme();
   const { palette, spacing, typo } = theme;
   const [open, setOpen] = useState(false);
@@ -62,7 +63,7 @@ const BoothBox = ({ date, place, title, category, onDelete }: BoothBoxProps) => 
         <IconButton size="small" color="inherit">
           <QrCodeIcon fontSize="small" />
         </IconButton>
-        <IconButton size="small" color="inherit">
+        <IconButton size="small" color="inherit" onClick={onEdit}>
           <EditIcon fontSize="small" />
         </IconButton>
         <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>

--- a/src/components/AdminPage/BoothParticipation.tsx
+++ b/src/components/AdminPage/BoothParticipation.tsx
@@ -22,7 +22,7 @@ const BoothParticipation = () => {
                     text-align: center;
                     color: ${palette.text.secondary};
                     border-radius: ${radius.sm}px;
-                    background-color: ${palette.background.inverse};
+                    background-color: ${palette.background.secondary};
                     padding: 50px;
                     border: ${palette.divider_custom.primary};
                 `}

--- a/src/components/AdminPage/GradeRankingCard.tsx
+++ b/src/components/AdminPage/GradeRankingCard.tsx
@@ -8,8 +8,8 @@ const GradeRankingCard = () => {
         <Box
             css={css`
                 width: 100%;
-                max-width: 300px; // 최대 너비 설정
-                margin: 0 auto; // 중앙 정렬
+                max-width: 300px; 
+                margin: 0 auto;
             `}
         >
             <Typography
@@ -27,12 +27,12 @@ const GradeRankingCard = () => {
             </Typography>
             <Paper
                 css={css`
-                    background-color: ${palette.background.inverse};
+                    background-color: ${palette.background.secondary};
                     border-radius: ${radius.sm}px;
                     padding: 16px;
                     text-align: center;
-                    width: 100%; // 부모 요소의 너비에 맞춤
-                    aspect-ratio: 1 / 1; // 정사각형 비율 유지
+                    width: 100%; 
+                    aspect-ratio: 1 / 1; 
                     display: flex;
                     flex-direction: column;
                     justify-content: center;

--- a/src/components/AdminPage/PointRankingCard.tsx
+++ b/src/components/AdminPage/PointRankingCard.tsx
@@ -27,7 +27,7 @@ const GradeRankingCard = () => {
             </Typography>
             <Paper
                 css={css`
-                    background-color: ${palette.background.inverse};
+                    background-color: ${palette.background.secondary};
                     border-radius: ${radius.sm}px;
                     padding: 16px;
                     text-align: center;

--- a/src/components/AdminPage/Popup/AddBooth.tsx
+++ b/src/components/AdminPage/Popup/AddBooth.tsx
@@ -1,0 +1,204 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogTitle, Button, css, useTheme } from '@mui/material';
+import InputBox from '@components/InputBox';
+import SelectBox from '@components/SelectBox';
+import TextareaBox from '@components/TextareaBox';
+import FileInputBox from '@components/FileInputBox';
+import { boothSchema } from '@utils/schemas/adminpopup-schema';
+import ErrorPopover from '@components/ErrorPopover';
+
+type BoothData = {
+  companyName: string;
+  companyType: string;
+  boothLocation: string;
+  boothNumber: string;
+  boothDescription: string;
+  imageFile: File | null;
+};
+
+const AddBooth = ({
+  open,
+  onClose,
+  mode = 'add',
+  initialData,
+}: {
+  open: boolean;
+  onClose: () => void;
+  mode?: 'add' | 'edit';
+  initialData?: BoothData;
+}) => {
+  const theme = useTheme();
+  const { palette, typo } = theme;
+
+  const [companyName, setCompanyName] = useState('');
+  const [companyType, setCompanyType] = useState('');
+  const [boothLocation, setBoothLocation] = useState('');
+  const [boothNumber, setBoothNumber] = useState('');
+  const [boothDescription, setBoothDescription] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const locationOptions = [
+    { value: 'hallA', text: 'Hall A' },
+    { value: 'hallB', text: 'Hall B' },
+    { value: 'hallC', text: 'Hall C' },
+  ];
+
+  // initialData 있을 때 상태 초기화
+  useEffect(() => {
+    if (initialData) {
+      setCompanyName(initialData.companyName);
+      setCompanyType(initialData.companyType);
+      setBoothLocation(initialData.boothLocation);
+      setBoothNumber(initialData.boothNumber);
+      setBoothDescription(initialData.boothDescription);
+      setImageFile(initialData.imageFile);
+    } else {
+      // 초기화 (수정 모드였다가 닫고 다시 열 경우 대비)
+      setCompanyName('');
+      setCompanyType('');
+      setBoothLocation('');
+      setBoothNumber('');
+      setBoothDescription('');
+      setImageFile(null);
+    }
+  }, [initialData, open]);
+
+  const handleSubmit = () => {
+    const result = boothSchema.safeParse({
+      companyName,
+      companyType,
+      boothLocation,
+      boothNumber,
+      boothDescription,
+      imageFile,
+    });
+
+    if (!result.success) {
+      const firstError = result.error.errors[0]?.message || '입력값을 다시 확인해 주세요.';
+      setFormError(firstError);
+      return;
+    }
+
+    if (mode === 'add') { //TODO: api 연동 시 mode에 따라 처리
+      console.log('등록 요청', result.data);
+    } else {
+      console.log('수정 요청', result.data);
+    }
+
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          borderRadius: '18px',
+          maxWidth: { xs: '90%', sm: '400px', md: '400px' },
+          margin: { xs: 2, sm: 3 },
+        },
+      }}
+    >
+      <DialogTitle
+        css={css`
+          font-size: 20px;
+          font-weight: bold;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.tertiary};
+          padding-bottom: 10px;
+          padding-top: 24px;
+          padding-left: 24px;
+        `}
+      >
+        {mode === 'add' ? '부스 등록' : '부스 수정'}
+      </DialogTitle>
+      <DialogContent
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+        `}
+      >
+        <InputBox
+          label="기업 이름"
+          id="companyName"
+          isRequired
+          placeholder="기업 이름을 입력해 주세요."
+          value={companyName}
+          onChange={setCompanyName}
+        />
+
+        <InputBox
+          label="기업 유형"
+          id="companyType"
+          isRequired
+          placeholder="기업 유형을 입력해 주세요."
+          value={companyType}
+          onChange={setCompanyType}
+        />
+
+        <SelectBox
+          id="boothLocation"
+          label="부스 장소"
+          isRequired
+          placeholder="선택"
+          items={locationOptions}
+          value={boothLocation}
+          onChange={setBoothLocation}
+        />
+
+        <InputBox
+          label="부스 번호"
+          id="boothNumber"
+          isRequired
+          placeholder="상세 번호를 입력해 주세요."
+          value={boothNumber}
+          onChange={setBoothNumber}
+        />
+
+        <TextareaBox
+          label="부스 설명"
+          id="boothDescription"
+          isRequired
+          placeholder="부스 설명을 입력해 주세요."
+          max_length={150}
+          value={boothDescription}
+          onChange={setBoothDescription}
+        />
+
+        <FileInputBox
+          label="이미지"
+          id="imageFile"
+          placeholder="필요한 이미지를 첨부해 주세요."
+          onChange={setImageFile}
+        />
+
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          css={css`
+            background-color: ${palette.background.quinary};
+            font-family: ${typo.fontFamily.Pretendard};
+            color: ${palette.text.primary};
+            border-radius: 12px;
+            padding: 12px 20px;
+            font-weight: bold;
+            font-size: 16px;
+            border: none;
+          `}
+        >
+          {mode === 'add' ? '등록하기' : '완료'}
+        </Button>
+      </DialogContent>
+      <ErrorPopover error={formError} />
+    </Dialog>
+  );
+};
+
+export default AddBooth;

--- a/src/components/AdminPage/Popup/AddSession.tsx
+++ b/src/components/AdminPage/Popup/AddSession.tsx
@@ -1,0 +1,219 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogTitle, Button, css, useTheme } from '@mui/material';
+import InputBox from '@components/InputBox';
+import SelectBox from '@components/SelectBox';
+import TextareaBox from '@components/TextareaBox';
+import FileInputBox from '@components/FileInputBox';
+import { sessionSchema } from '@utils/schemas/adminpopup-schema';
+import ErrorPopover from '@components/ErrorPopover';
+
+interface AddSessionProps {
+  open: boolean;
+  onClose: () => void;
+  mode?: 'add' | 'edit';
+  initialData?: any;
+}
+
+const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProps) => {
+  const theme = useTheme();
+  const { palette, typo } = theme;
+
+  const [title, setTitle] = useState('');
+  const [presenter, setPresenter] = useState('');
+  const [presenterRole, setPresenterRole] = useState('');
+  const [date, setDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [sessionDescription, setSessionDescription] = useState('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [maxCapacity, setMaxCapacity] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (mode === 'edit' && initialData) {
+      setTitle(initialData.title || '');
+      setPresenter(initialData.presenter || '');
+      setPresenterRole(initialData.presenterRole || '');
+      setDate(initialData.date || '');
+      setStartTime(initialData.startTime || '');
+      setEndTime(initialData.endTime || '');
+      setSessionDescription(initialData.sessionDescription || '');
+      setImageFile(initialData.imageFile || null);
+      setMaxCapacity(initialData.maxCapacity || '');
+    } else {
+      // add 모드일 때 초기화
+      setTitle('');
+      setPresenter('');
+      setPresenterRole('');
+      setDate('');
+      setStartTime('');
+      setEndTime('');
+      setSessionDescription('');
+      setImageFile(null);
+      setMaxCapacity('');
+    }
+  }, [open, mode, initialData]);
+
+  const capacityOptions = [
+    { value: '150', text: '150명' },
+    { value: '200', text: '200명' },
+    { value: '250', text: '250명' },
+  ];
+
+  const handleSubmit = () => {
+    const result = sessionSchema.safeParse({
+      title,
+      presenter,
+      presenterRole,
+      date,
+      startTime,
+      endTime,
+      sessionDescription,
+      imageFile,
+      maxCapacity,
+    });
+
+    if (!result.success) {
+      const firstError = result.error.errors[0]?.message || '입력값을 다시 확인해 주세요.';
+      setFormError(firstError);
+      return;
+    }
+
+    if (mode === 'edit') {
+      console.log('수정 완료', result.data);
+    } else {
+      console.log('등록 완료', result.data);
+    }
+
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          borderRadius: '18px',
+          maxWidth: { xs: '90%', sm: '400px', md: '400px' },
+          margin: { xs: 2, sm: 3 },
+        },
+      }}
+    >
+      <DialogTitle
+        css={css`
+          font-size: 20px;
+          font-weight: bold;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.tertiary};
+          padding-bottom: 10px;
+          padding-top: 24px;
+          padding-left: 24px;
+        `}
+      >
+        {mode === 'edit' ? '세션 수정' : '세션 등록'}
+      </DialogTitle>
+      <DialogContent
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+        `}
+      >
+        <InputBox
+          label="제목"
+          id="title"
+          isRequired value={title}
+          onChange={setTitle} 
+          placeholder="세션 제목을 입력해 주세요."
+        />
+        <InputBox
+          label="발표자"
+          id="presenter"
+          isRequired
+          value={presenter}
+          onChange={setPresenter}
+          placeholder="발표자 성함을 입력해 주세요."
+        />
+        <InputBox
+          label="발표자의 직책"
+          id="presenterRole"
+          isRequired
+          value={presenterRole}
+          onChange={setPresenterRole}
+          placeholder="발표자의 직책을 입력해 주세요."
+        />
+        <InputBox
+          label="진행일"
+          id="date" isRequired
+          value={date}
+          onChange={setDate}
+          placeholder="진행 날짜를 입력해 주세요."
+        />
+        <InputBox
+          label="시작 시간"
+          id="startTime"
+          isRequired
+          value={startTime}
+          onChange={setStartTime}
+          placeholder="시작 시간을 입력해 주세요."
+        />
+        <InputBox
+          label="종료 시간"
+          id="endTime"
+          isRequired
+          value={endTime}
+          onChange={setEndTime}
+          placeholder="종료 시간을 입력해 주세요."
+        />
+        <TextareaBox
+          label="세션 설명"
+          id="sessionDescription"
+          isRequired
+          max_length={150}
+          value={sessionDescription}
+          onChange={setSessionDescription}
+          placeholder="세션 설명을 입력해 주세요."
+        />
+        <FileInputBox
+          label="이미지"
+          id="imageFile"
+          placeholder="필요한 이미지를 첨부해 주세요."
+          onChange={setImageFile}
+        />
+        <SelectBox
+          id="maxCapacity"
+          label="최대 수용 인원"
+          isRequired placeholder="선택"
+          items={capacityOptions}
+          value={maxCapacity}
+          onChange={setMaxCapacity}
+        />
+
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          css={css`
+            background-color: ${palette.background.quinary};
+            font-family: ${typo.fontFamily.Pretendard};
+            color: ${palette.text.primary};
+            border-radius: 12px;
+            padding: 12px 20px;
+            font-weight: bold;
+            font-size: 16px;
+            border: none;
+          `}
+        >
+          {mode === 'add' ? '등록하기' : '완료'}
+        </Button>
+      </DialogContent>
+      <ErrorPopover error={formError} />
+    </Dialog>
+  );
+};
+
+export default AddSession;

--- a/src/components/AdminPage/Popup/ConferenceForm.tsx
+++ b/src/components/AdminPage/Popup/ConferenceForm.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, Button, css, useTheme } from '@mui/material';
+import InputBox from '@components/InputBox';
+import SelectBox from '@components/SelectBox';
+import { conferenceSchema } from '@utils/schemas/adminpopup-schema';
+import ErrorPopover from '@components/ErrorPopover';
+
+interface ConferenceFormProps {
+  mode: 'add' | 'edit';
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: any) => void;
+  initialData?: {
+    name: string;
+    host: string;
+    startDate: string;
+    startTime: string;
+    endDate: string;
+    endTime: string;
+    place: string;
+    location: string;
+    conferenceType: string;
+  };
+}
+
+const ConferenceForm = ({ mode, open, onClose, onSubmit, initialData }: ConferenceFormProps) => {
+  const theme = useTheme();
+  const { palette, typo } = theme;
+
+  // State 초기화
+  const [name, setName] = useState('');
+  const [host, setHost] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [place, setPlace] = useState('');
+  const [location, setLocation] = useState('');
+  const [conferenceType, setConferenceType] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  // 수정 모드 시 초기값 세팅
+  useEffect(() => {
+    if (mode === 'edit' && initialData) {
+      setName(initialData.name);
+      setHost(initialData.host);
+      setStartDate(initialData.startDate);
+      setStartTime(initialData.startTime);
+      setEndDate(initialData.endDate);
+      setEndTime(initialData.endTime);
+      setPlace(initialData.place);
+      setLocation(initialData.location);
+      setConferenceType(initialData.conferenceType);
+    } else {
+      // 추가 모드 시 초기화
+      setName('');
+      setHost('');
+      setStartDate('');
+      setStartTime('');
+      setEndDate('');
+      setEndTime('');
+      setPlace('');
+      setLocation('');
+      setConferenceType('');
+    }
+  }, [mode, initialData, open]);
+
+  const locationTypeOptions = [
+    { value: '그랜드볼룸', text: '그랜드볼룸' },
+    { value: '아셈볼룸', text: '아셈볼룸' },
+    { value: 'THE PLATZ', text: 'THE PLATZ' },
+    { value: '오디토리움', text: '오디토리움' },
+  ];
+
+  const conferenceTypeOptions = [
+    { value: 'IT', text: 'IT' },
+    { value: '무역', text: '무역' },
+    { value: '산업', text: '산업' },
+  ];
+
+  const handleSubmit = () => {
+    const result = conferenceSchema.safeParse({
+      name,
+      host,
+      startDate,
+      startTime,
+      endDate,
+      endTime,
+      place,
+      location,
+      conferenceType,
+    });
+
+    if (!result.success) {
+      const firstError = result.error.errors[0]?.message || '입력값을 다시 확인해 주세요.';
+      setFormError(firstError);
+      return;
+    }
+
+    onSubmit(result.data);
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      PaperProps={{
+        sx: {
+          borderRadius: '18px',
+          maxWidth: { xs: '90%', sm: '400px' },
+          margin: { xs: 2, sm: 3 },
+        },
+      }}
+    >
+      <DialogTitle
+        css={css`
+          font-size: 20px;
+          font-weight: bold;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+        `}
+      >
+        {mode === 'add' ? '컨퍼런스 등록' : '컨퍼런스 수정'}
+      </DialogTitle>
+      <DialogContent
+        css={css`
+          display: flex;
+          flex-direction: column;
+          gap: 20px;
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+        `}
+      >
+        <InputBox
+            label="컨퍼런스 명"
+            id="name"
+            isRequired
+            placeholder="컨퍼런스 명을 입력해 주세요."
+            value={name}
+            onChange={setName}
+        />
+        <InputBox
+            label="컨퍼런스 주최자"
+            id="host"
+            isRequired
+            placeholder="주최자를 입력해 주세요."
+            value={host}
+            onChange={setHost}
+        />
+        <InputBox
+            label="시작일"
+            id="startDate"
+            isRequired
+            placeholder="컨퍼런스 시작 날짜를 입력해 주세요."
+            value={startDate}
+            onChange={setStartDate}
+        />
+        <InputBox
+            label="시작 시간"
+            id="startTime"
+            isRequired
+            placeholder="컨퍼런스 시작 시간을 입력해 주세요."
+            value={startTime}
+            onChange={setStartTime}
+        />
+        <InputBox
+            label="종료일"
+            id="endDate"
+            isRequired
+            placeholder="컨퍼런스 종료 날짜를 입력해 주세요."
+            value={endDate}
+            onChange={setEndDate}
+        />
+        <InputBox
+            label="종료 시간"
+            id="endTime"
+            isRequired
+            placeholder="컨퍼런스 종료 시간을 입력해 주세요."
+            value={endTime}
+            onChange={setEndTime}
+        />
+        <InputBox
+            label="컨퍼런스 장소"
+            id="place"
+            isRequired
+            placeholder="장소를 입력해 주세요."
+            value={place}
+            onChange={setPlace}
+        />
+        <SelectBox
+            id="locationType"
+            label="컨퍼런스 위치"
+            isRequired
+            placeholder="선택"
+            items={locationTypeOptions}
+            value={location}
+            onChange={setLocation}
+        />
+        <SelectBox 
+            id="conferenceType"
+            label="컨퍼런스 유형"
+            isRequired
+            placeholder="선택"
+            items={conferenceTypeOptions}
+            value={conferenceType}
+            onChange={setConferenceType}
+        />
+
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          css={css`
+            background-color: ${palette.background.quinary};
+            font-family: ${typo.fontFamily.Pretendard};
+            color: ${palette.text.primary};
+            border-radius: 12px;
+            padding: 12px 20px;
+            font-weight: bold;
+            font-size: 16px;
+            border: none;
+          `}
+        >
+          {mode === 'add' ? '등록하기' : '완료'}
+        </Button>
+      </DialogContent>
+      <ErrorPopover error={formError} />
+    </Dialog>
+  );
+};
+
+export default ConferenceForm;

--- a/src/components/AdminPage/RegButtons.tsx
+++ b/src/components/AdminPage/RegButtons.tsx
@@ -3,27 +3,49 @@ import { Box, Button, Modal, Typography } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
-import ConferenceModal from './Modal/ConferenceModal';
+import ConferenceForm from './Popup/ConferenceForm';
 
 const ConferenceRegistration = () => {
   const { palette, typography, radius } = useTheme();
   const [isConferenceRegistered, setIsConferenceRegistered] = useState(false);
   const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<'add' | 'edit'>('add');
+  const [conferenceData, setConferenceData] = useState<any>(null);
 
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
   const handleRegister = () => {
-    handleOpen(); // 모달 열기
+    setMode('add');
+    setConferenceData(null);
+    handleOpen();
   };
 
   const handleModify = () => {
     if (isConferenceRegistered) {
-      // TODO: 컨퍼런스 수정 로직
+      // 임시 데이터로 초기값 세팅 (실제 데이터는 API에서 가져오거나 state로 관리)
+      const dummyData = {
+        name: '샘플 컨퍼런스',
+        host: '주최자',
+        startDate: '2025.04.01',
+        startTime: '10:00',
+        endDate: '2025.04.01',
+        endTime: '17:00',
+        location: '그랜드볼룸',
+        placeType: 'on-site',
+        conferenceType: 'IT',
+        description: '컨퍼런스 설명입니다.',
+        imageFile: null,
+      };
+
+      setMode('edit');
+      setConferenceData(dummyData);
+      handleOpen();
     }
   };
 
-  const handleModalRegister = () => {
+  const handleModalSubmit = (data: any) => {
+    console.log('등록 또는 수정 완료:', data);
     setIsConferenceRegistered(true);
     handleClose();
   };
@@ -101,7 +123,13 @@ const ConferenceRegistration = () => {
         aria-describedby="modal-modal-description"
         disableEnforceFocus
       >
-        <ConferenceModal onClose={handleClose} onRegister={handleModalRegister} />
+        <ConferenceForm
+          mode={mode}
+          open={open}
+          onClose={handleClose}
+          onSubmit={handleModalSubmit}
+          initialData={conferenceData}
+        />
       </Modal>
     </Box>
   );

--- a/src/components/AdminPage/SessionBox.tsx
+++ b/src/components/AdminPage/SessionBox.tsx
@@ -14,9 +14,10 @@ interface SessionBoxProps {
   speaker: string;
   chartData?: any[];
   onDelete: () => void;
+  onEdit: () => void;
 }
 
-const SessionBox = ({ date, place, time, title, speaker, onDelete }: SessionBoxProps) => {
+const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: SessionBoxProps) => {
   const theme = useTheme();
   const { palette, spacing, typo } = theme;
   const [open, setOpen] = useState(false);
@@ -63,7 +64,7 @@ const SessionBox = ({ date, place, time, title, speaker, onDelete }: SessionBoxP
         <IconButton size="small" color="inherit">
           <QrCodeIcon fontSize="small" />
         </IconButton>
-        <IconButton size="small" color="inherit">
+        <IconButton size="small" color="inherit" onClick={onEdit}>
           <EditIcon fontSize="small" />
         </IconButton>
         <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -22,7 +22,7 @@ const SessionParticipation = () => {
                     text-align: center;
                     color: ${palette.text.secondary};
                     border-radius: ${radius.sm}px;
-                    background-color: ${palette.background.inverse};
+                    background-color: ${palette.background.secondary};
                     padding: 50px;
                     border: ${palette.divider_custom.primary};
                 `}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -11,8 +11,8 @@ import FindIdPage from './pages/FindIdPage';
 import ResetPasswordPage from './pages/ResetPasswordPage';
 import OnBoarding from './pages/OnBoarding';
 import DefaultNavLayout from './layouts/DefaultNav';
-import SessionDetail from './pages/SessionDetail';
-import BoothDetail from './pages/BoothDetail';
+import SessionDetail from './pages/Session';
+import BoothDetail from './pages/Booth';
 import Mypage from './pages/Mypage';
 
 const router = createBrowserRouter([
@@ -77,11 +77,11 @@ const router = createBrowserRouter([
         element: <NotFound />,
       },
       {
-        path: '/sessionDetail' /* 추후 뺄 예정 */,
+        path: '/admin/session' /* 추후 뺄 예정 */,
         element: <SessionDetail />,
       },
       {
-        path: '/boothDetail' /* 추후 뺄 예정 */,
+        path: '/admin/booth' /* 추후 뺄 예정 */,
         element: <BoothDetail />,
       },
     ],

--- a/src/routes/pages/Booth.tsx
+++ b/src/routes/pages/Booth.tsx
@@ -1,0 +1,80 @@
+import { Typography, Box, Button } from '@mui/material';
+import Header from '@components/AdminHeader';
+import BoothBox from '@components/AdminPage/BoothBox';
+import { css, useTheme } from '@mui/material/styles';
+import { typography } from '@styles/foundation';
+import AddIcon from '@mui/icons-material/Add';
+
+const BoothDetail = () => {
+  const theme = useTheme();
+  const { palette, spacing } = theme;
+
+  const pageStyle = css`
+    display: flex;
+    flex-direction: column;
+    padding: ${spacing(2)};
+  `;
+
+  const titleStyle = css`
+    color: ${palette.text.primary};
+    font-family: ${typography.fontFamily.Pretendard};
+    font-size: 26px;
+    font-weight: bold;
+  `;
+
+  const registerButtonStyle = css`
+    background-color: transparent;
+    color: ${palette.text.quaternary};
+    border-color: ${palette.border.secondary};
+    border-radius: 18px;
+    padding: 8px 16px;
+    border: 1px solid ${palette.border.secondary};
+  `;
+
+  const BoothListStyle = css`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing(2)}px;
+  `;
+
+  const handleRegisterClick = () => {
+    //TODO: 부스 등록 모달 이동
+  };
+
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
+
+  return (
+    <Box css={pageStyle}>
+      <Header />
+      <Box display="flex" justifyContent="space-between" alignItems="center" mt={2} mb={2}>
+        <Typography variant="h4" css={titleStyle}>
+          부스 참여 현황
+        </Typography>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={handleRegisterClick}
+          css={registerButtonStyle}
+        >
+          부스 등록
+        </Button>
+      </Box>
+
+      {/* Booth List */}
+      <Box css={BoothListStyle} sx={{gap: 2}}>
+        {/* 예시 데이터 */}
+        <BoothBox
+          date="9/15"
+          place="부스 A"
+          title="DevWave"
+          category="AI"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default BoothDetail;

--- a/src/routes/pages/Booth.tsx
+++ b/src/routes/pages/Booth.tsx
@@ -1,13 +1,39 @@
+import { useState } from 'react';
 import { Typography, Box, Button } from '@mui/material';
 import Header from '@components/AdminHeader';
 import BoothBox from '@components/AdminPage/BoothBox';
 import { css, useTheme } from '@mui/material/styles';
 import { typography } from '@styles/foundation';
 import AddIcon from '@mui/icons-material/Add';
+import AddBooth from '@components/AdminPage/Popup/AddBooth';
 
-const BoothDetail = () => {
+const Booth = () => {
   const theme = useTheme();
   const { palette, spacing } = theme;
+
+  const [isAddBoothOpen, setIsAddBoothOpen] = useState(false);
+  const [editMode, setEditMode] = useState<'add' | 'edit'>('add');
+  const [editData, setEditData] = useState<any | null>(null);
+
+  const handleRegisterClick = () => {
+    setEditMode('add');
+    setEditData(null);
+    setIsAddBoothOpen(true);
+  };
+
+  const handleCloseAddBooth = () => {
+    setIsAddBoothOpen(false);
+  };
+
+  const handleEditBooth = (boothInfo: any) => {
+    setEditMode('edit');
+    setEditData(boothInfo);
+    setIsAddBoothOpen(true);
+  };
+
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
 
   const pageStyle = css`
     display: flex;
@@ -37,14 +63,6 @@ const BoothDetail = () => {
     gap: ${spacing(2)}px;
   `;
 
-  const handleRegisterClick = () => {
-    //TODO: 부스 등록 모달 이동
-  };
-
-  const handleDeleteSession = () => {
-    console.log('세션 삭제');
-  };
-
   return (
     <Box css={pageStyle}>
       <Header />
@@ -52,29 +70,40 @@ const BoothDetail = () => {
         <Typography variant="h4" css={titleStyle}>
           부스 참여 현황
         </Typography>
-        <Button
-          startIcon={<AddIcon />}
-          onClick={handleRegisterClick}
-          css={registerButtonStyle}
-        >
+        <Button startIcon={<AddIcon />} onClick={handleRegisterClick} css={registerButtonStyle}>
           부스 등록
         </Button>
       </Box>
 
-      {/* Booth List */}
-      <Box css={BoothListStyle} sx={{gap: 2}}>
-        {/* 예시 데이터 */}
-        <BoothBox
+      <Box css={BoothListStyle}>
+        <BoothBox //임시 확인용
           date="9/15"
           place="부스 A"
           title="DevWave"
           category="AI"
           chartData={[]}
           onDelete={handleDeleteSession}
+          onEdit={() =>
+            handleEditBooth({
+              companyName: 'DevWave',
+              companyType: '스타트업',
+              boothLocation: 'hallA',
+              boothNumber: 'A-01',
+              boothDescription: 'AI 관련 기술 소개',
+              imageFile: null,
+            })
+          }
         />
       </Box>
+
+      <AddBooth
+        open={isAddBoothOpen}
+        onClose={handleCloseAddBooth}
+        mode={editMode}
+        initialData={editData}
+      />
     </Box>
   );
 };
 
-export default BoothDetail;
+export default Booth;

--- a/src/routes/pages/Session.tsx
+++ b/src/routes/pages/Session.tsx
@@ -1,0 +1,91 @@
+import { Typography, Box, Button } from '@mui/material';
+import Header from '@components/AdminHeader';
+import SessionBox from '@components/AdminPage/SessionBox';
+import { css, useTheme } from '@mui/material/styles';
+import { typography } from '@styles/foundation';
+import AddIcon from '@mui/icons-material/Add';
+
+const SessionDetail = () => {
+  const theme = useTheme();
+  const { palette, spacing } = theme;
+
+  const pageStyle = css`
+    display: flex;
+    flex-direction: column;
+    padding: ${spacing(2)};
+  `;
+
+  const titleStyle = css`
+    color: ${palette.text.primary};
+    font-family: ${typography.fontFamily.Pretendard};
+    font-size: 26px;
+    flex: 1;
+    font-weight: bold;
+  `;
+
+  const registerButtonStyle = css`
+    background-color: transparent;
+    color: ${palette.text.quaternary};
+    border-color: ${palette.border.secondary};
+    border-radius: 18px;
+    padding: 8px 16px;
+    border: 1px solid ${palette.border.secondary};
+  `;
+
+  const sessionListStyle = css`
+    display: flex;
+    flex-direction: column;
+    gap: ${spacing(2)}px;
+  `;
+
+  const handleRegisterClick = () => {
+    //TODO: 세션 등록 모달 이동
+  };
+
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
+
+  return (
+    <Box css={pageStyle}>
+      <Header />
+
+      <Box display="flex" justifyContent="space-between" alignItems="center" mt={2} mb={2}>
+        <Typography variant="h4" css={titleStyle}>
+          세션 참여 현황
+        </Typography>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={handleRegisterClick}
+          css={registerButtonStyle}
+        >
+          세션 등록
+        </Button>
+      </Box>
+
+      {/* Session List */}
+      <Box css={sessionListStyle} sx={{gap: 2}}>
+        <SessionBox
+          date="9/15"
+          place="세션 1-1"
+          title="최신 기술 동향"
+          time="10:30-11:30"
+          speaker="김지혁"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+        <SessionBox
+          date="9/15"
+          place="세션 1-2"
+          title="최신 기술 동향"
+          time="10:30-11:30"
+          speaker="홍길동"
+          chartData={[]}
+          onDelete={handleDeleteSession}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default SessionDetail;

--- a/src/routes/pages/Session.tsx
+++ b/src/routes/pages/Session.tsx
@@ -1,13 +1,38 @@
+import { useState } from 'react';
 import { Typography, Box, Button } from '@mui/material';
 import Header from '@components/AdminHeader';
 import SessionBox from '@components/AdminPage/SessionBox';
 import { css, useTheme } from '@mui/material/styles';
 import { typography } from '@styles/foundation';
 import AddIcon from '@mui/icons-material/Add';
+import AddSession from '@components/AdminPage/Popup/AddSession';
 
-const SessionDetail = () => {
+const Session = () => {
   const theme = useTheme();
   const { palette, spacing } = theme;
+  const [openAddSession, setOpenAddSession] = useState(false);
+  const [mode, setMode] = useState<'add' | 'edit'>('add');
+  const [editData, setEditData] = useState<any | null>(null);
+
+  const handleRegisterClick = () => {
+    setMode('add');
+    setEditData(null);
+    setOpenAddSession(true);
+  };
+
+  const handleCloseAddSession = () => {
+    setOpenAddSession(false);
+  };
+  
+  const handleDeleteSession = () => {
+    console.log('세션 삭제');
+  };
+
+  const handleEditSession = (sessionData: any) => {
+    setMode('edit');
+    setEditData(sessionData);
+    setOpenAddSession(true);
+  };
 
   const pageStyle = css`
     display: flex;
@@ -38,13 +63,6 @@ const SessionDetail = () => {
     gap: ${spacing(2)}px;
   `;
 
-  const handleRegisterClick = () => {
-    //TODO: 세션 등록 모달 이동
-  };
-
-  const handleDeleteSession = () => {
-    console.log('세션 삭제');
-  };
 
   return (
     <Box css={pageStyle}>
@@ -65,7 +83,7 @@ const SessionDetail = () => {
 
       {/* Session List */}
       <Box css={sessionListStyle} sx={{gap: 2}}>
-        <SessionBox
+      <SessionBox
           date="9/15"
           place="세션 1-1"
           title="최신 기술 동향"
@@ -73,19 +91,30 @@ const SessionDetail = () => {
           speaker="김지혁"
           chartData={[]}
           onDelete={handleDeleteSession}
-        />
-        <SessionBox
-          date="9/15"
-          place="세션 1-2"
-          title="최신 기술 동향"
-          time="10:30-11:30"
-          speaker="홍길동"
-          chartData={[]}
-          onDelete={handleDeleteSession}
+          onEdit={() =>
+            handleEditSession({
+              title: '최신 기술 동향',
+              presenter: '김지혁',
+              presenterRole: '수석 연구원',
+              date: '9/15',
+              startTime: '10:30',
+              endTime: '11:30',
+              sessionDescription: 'AI 및 최신 트렌드 소개 세션',
+              imageFile: null,
+              maxCapacity: '200',
+            })
+          }
         />
       </Box>
+
+      <AddSession
+        open={openAddSession}
+        onClose={handleCloseAddSession}
+        mode={mode}
+        initialData={editData}
+      />
     </Box>
   );
 };
 
-export default SessionDetail;
+export default Session;

--- a/src/utils/schemas/adminpopup-schema.ts
+++ b/src/utils/schemas/adminpopup-schema.ts
@@ -34,4 +34,24 @@ export const boothSchema = z.object({
     boothDescription: z.string().max(150, '부스 설명은 150자 이내로 입력해 주세요.'),
     imageFile: z.instanceof(File).optional().or(z.null()),
   });
-  
+
+  export const conferenceSchema = z.object({
+    name: z.string().max(30, { message: '컨퍼런스 명은 최대 30자까지 입력 가능합니다.' }),
+    host: z.string().max(10, { message: '컨퍼런스 주최자는 최대 10자까지 입력 가능합니다.' }),
+    startDate: z.string()
+      .regex(dateRegex, { message: '시작일은 YYYY.MM.DD 형식으로 입력해 주세요.' })
+      .refine(isFutureDate, { message: '시작일은 오늘 이후의 날짜만 입력 가능합니다.' }),
+    startTime: z.string()
+      .regex(timeRegex, { message: '시작 시간은 24시간제로 00:00 형식으로 입력해 주세요.' }),
+    endDate: z.string()
+      .regex(dateRegex, { message: '종료일은 YYYY.MM.DD 형식으로 입력해 주세요.' })
+      .refine(isFutureDate, { message: '종료일은 오늘 이후의 날짜만 입력 가능합니다.' }),
+    endTime: z.string()
+      .regex(timeRegex, { message: '종료 시간은 24시간제로 00:00 형식으로 입력해 주세요.' }),
+    location: z.enum(['그랜드볼룸', '아셈볼룸', 'THE PLATZ', '오리토리움'], {
+      errorMap: () => ({ message: '컨퍼런스 위치를 선택해 주세요.' }),
+    }),
+    conferenceType: z.enum(['IT', '무역', '산업'], {
+      errorMap: () => ({ message: '컨퍼런스 유형을 선택해 주세요.' }),
+    }),
+  });

--- a/src/utils/schemas/adminpopup-schema.ts
+++ b/src/utils/schemas/adminpopup-schema.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+// 정규식 패턴
+const dateRegex = /^\d{4}\.\d{2}\.\d{2}$/; // YYYY.MM.DD
+const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/; // 24시간제 00:00 ~ 23:59
+
+const isFutureDate = (dateString: string) => {
+  const date = new Date(dateString.replace(/\./g, '-'));
+  const now = new Date();
+  return date > now;
+};
+
+// 세션 등록 스키마
+export const sessionSchema = z.object({
+    title: z.string().min(1, '세션 제목을 입력해 주세요.').max(30, '제목은 30자 이내로 입력해 주세요.'),
+    presenter: z.string().min(1, '발표자 성함을 입력해 주세요.'),
+    presenterRole: z.string().min(1, '발표자의 직책을 입력해 주세요.').max(15, '직책은 15자 이내로 입력해 주세요.'),
+    date: z.string()
+      .regex(dateRegex, '진행일은 YYYY.MM.DD 형식으로 입력해 주세요.')
+      .refine(isFutureDate, '진행일은 미래 날짜여야 합니다.'),
+    startTime: z.string().regex(timeRegex, '시작 시간은 24시간제 HH:MM 형식으로 입력해 주세요.'),
+    endTime: z.string().regex(timeRegex, '종료 시간은 24시간제 HH:MM 형식으로 입력해 주세요.'),
+    sessionDescription: z.string().min(1, '세션 설명을 입력해 주세요.').max(150, '세션 설명은 150자 이내로 입력해 주세요.'),
+    imageFile: z.any().optional(),
+    maxCapacity: z.enum(['150', '200', '250'], { required_error: '최대 인원 수용을 선택해 주세요.' }),
+  });
+
+//  부스 등록 스키마
+export const boothSchema = z.object({
+    companyName: z.string().min(1, '기업 이름을 입력해 주세요.').max(10, '기업 이름은 10자 이내로 입력해 주세요.'),
+    companyType: z.string().min(1, '기업 유형을 입력해 주세요.').max(10, '기업 유형은 10자 이내로 입력해 주세요.'),
+    boothLocation: z.string().min(1, '부스 장소를 선택해 주세요.'),
+    boothNumber: z.string().min(1, '부스 번호를 입력해 주세요.'),
+    boothDescription: z.string().max(150, '부스 설명은 150자 이내로 입력해 주세요.'),
+    imageFile: z.instanceof(File).optional().or(z.null()),
+  });
+  


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/addpopup` → `dev`

<br/>

## ✅ 작업 내용
`코드가 많이 더럽습니다..`
- 컨퍼런스 등록, 수정 팝업 구현
- 세션 등록, 수정 팝업 구현
- 부스 등록, 수정 팝업 구현
- zod 스키마 사용
- 관리자 페이지 세션, 부스, 랭킹 컴포넌트 배경색 수정
- 세션, 부스 상세 현황 페이지 파일 이름 변동
<br/>

## 🌠 이미지 첨부
**1. 컨퍼런스 등록 -> 수정**

https://github.com/user-attachments/assets/e810b759-7695-4619-af6d-b5b87cd038de

**2. 세션 등록 (error 컴포넌트 사용 예시)**

https://github.com/user-attachments/assets/c8976155-3c32-43ee-9da2-d9a9af078421

**3. 세션 수정 팝업 (임시로 넣은 값 띄우기)**
<img width="1512" alt="스크린샷 2025-03-18 오후 5 39 55" src="https://github.com/user-attachments/assets/ef80cb60-918b-42ec-b1b8-54250ebe77d7" />

**4. 부스 등록**
<img width="1512" alt="스크린샷 2025-03-18 오후 5 40 10" src="https://github.com/user-attachments/assets/98152716-4bd6-408e-a828-a0bb4e979231" />

**5. 부스 수정**
<img width="1512" alt="스크린샷 2025-03-18 오후 5 40 16" src="https://github.com/user-attachments/assets/dc862401-f69a-413d-9b96-8799115b12aa" />

<br/>

## ✏️ 앞으로의 과제

- 관리자 대시보드 등록 전/후 UI
- 랭킹 팝업 구현

<br/>

