### PR TITLE
feat(dashboard): 대시보드 조건부 랜더링, 랭킹 팝업 구현

### DIFF
--- a/src/components/AdminPage/BoothParticipation.tsx
+++ b/src/components/AdminPage/BoothParticipation.tsx
@@ -6,7 +6,7 @@ import AddBooth from './Popup/AddBooth';
 import { useConferenceStore } from '@stores/client/useConferenceStore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useNavigate } from 'react-router-dom';
-import { useBoothStore } from '@stores/client/UseBoothStore';
+import { useBoothStore } from '@stores/client/useBoothStore';
 
 const BoothParticipation = () => {
     const { palette, typography, radius } = useTheme();

--- a/src/components/AdminPage/BoothParticipation.tsx
+++ b/src/components/AdminPage/BoothParticipation.tsx
@@ -1,58 +1,129 @@
+import { useState } from 'react';
 import { Box, Typography, Paper } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import AddBooth from './Popup/AddBooth';
+import { useConferenceStore } from '@stores/client/useConferenceStore';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { useNavigate } from 'react-router-dom';
+import { useBoothStore } from '@stores/client/UseBoothStore';
 
 const BoothParticipation = () => {
     const { palette, typography, radius } = useTheme();
+    const isConferenceRegistered = useConferenceStore((state) => state.isConferenceRegistered);
+    const { isBoothRegistered, hasAggregationData } = useBoothStore();
+    const [showAddBooth, setShowAddBooth] = useState(false);
+    const navigate = useNavigate();
+
+    const handleAddIconClick = () => {
+        if (isConferenceRegistered) {
+            setShowAddBooth(true);
+        } else {
+            alert('컨퍼런스를 등록해주세요');
+        }
+    };
+
+    const handleChevronClick = () => {
+        if (isConferenceRegistered) {
+            navigate('/admin/booth');
+        } else {
+            alert('컨퍼런스를 등록해주세요');
+        }
+    };
+
     return (
-        <Box>
-            <Typography 
-                variant="subtitle1" 
-                fontWeight="bold" 
-                mb={1}
-                css={css`
-                    color: ${palette.text.primary};
-                    font-family: ${typography.fontFamily};
-                `}
-            >
-                부스 참여 현황
-            </Typography>
-            <Paper
-                css={css`
-                    text-align: center;
-                    color: ${palette.text.secondary};
-                    border-radius: ${radius.sm}px;
-                    background-color: ${palette.background.secondary};
-                    padding: 50px;
-                    border: ${palette.divider_custom.primary};
-                `}
-            >
-                <AddIcon 
+        <Box position="relative">
+            <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                <Typography 
+                    variant="subtitle1" 
+                    fontWeight="bold"
                     css={css`
-                        font-size: 40px;
-                        color: ${palette.text.secondary};
-                        margin-bottom: 16px;
+                        color: ${palette.text.primary};
+                        font-family: ${typography.fontFamily};
                     `}
+                >
+                    부스 참여 현황
+                </Typography>
+                <ChevronRightIcon 
+                    css={css`
+                        color: ${palette.icon.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleChevronClick}
                 />
-                <Typography 
-                    variant="body2"
+            </Box>
+
+            {!isConferenceRegistered ? (
+                <Paper
                     css={css`
+                        text-align: center;
                         color: ${palette.text.secondary};
-                        font-family: ${typography.fontFamily};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleAddIconClick}
+                >
+                    <AddIcon 
+                        css={css`
+                            font-size: 40px;
+                            color: ${palette.text.secondary};
+                            margin-bottom: 16px;
+                        `}
+                    />
+                    <Typography variant="body2">등록된 부스가 없습니다.</Typography>
+                    <Typography variant="body2">컨퍼런스 등록 후 확인 가능합니다.</Typography>
+                </Paper>
+            ) : !isBoothRegistered ? (
+                <Paper
+                    css={css`
+                        text-align: center;
+                        color: ${palette.text.secondary};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleAddIconClick}
+                >
+                    <AddIcon 
+                        css={css`
+                            font-size: 40px;
+                            color: ${palette.text.secondary};
+                            margin-bottom: 16px;
+                        `}
+                    />
+                    <Typography variant="body2">등록된 부스가 없습니다.</Typography>
+                    <Typography variant="body2">부스 등록 후 확인 가능합니다.</Typography>
+                </Paper>
+            ) : !hasAggregationData ? (
+                <Paper
+                    css={css`
+                        text-align: center;
+                        color: ${palette.text.secondary};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
                     `}
                 >
-                    등록된 부스가 없습니다.
-                </Typography>
-                <Typography 
-                    variant="body2"
-                    css={css`
-                        color: ${palette.text.secondary};
-                        font-family: ${typography.fontFamily};
-                    `}
-                >
-                    컨퍼런스 등록 후 확인 가능합니다.
-                </Typography>
-            </Paper>
+                    <Typography variant="body2" mb={1}>
+                        집계된 정보가 없습니다.
+                    </Typography>
+                </Paper>
+            ) : (
+                <Typography>집계된 부스 정보 표시</Typography>
+            )}
+
+            {showAddBooth && (
+                <AddBooth
+                    open={showAddBooth}
+                    onClose={() => setShowAddBooth(false)}
+                />
+            )}
         </Box>
     );
 };

--- a/src/components/AdminPage/Popup/AddBooth.tsx
+++ b/src/components/AdminPage/Popup/AddBooth.tsx
@@ -6,7 +6,7 @@ import TextareaBox from '@components/TextareaBox';
 import FileInputBox from '@components/FileInputBox';
 import { boothSchema } from '@utils/schemas/adminpopup-schema';
 import ErrorPopover from '@components/ErrorPopover';
-import { useBoothStore } from '@stores/client/UseBoothStore';
+import { useBoothStore } from '@stores/client/useBoothStore';
 
 export type BoothData = {
   companyName: string;

--- a/src/components/AdminPage/Popup/AddBooth.tsx
+++ b/src/components/AdminPage/Popup/AddBooth.tsx
@@ -6,8 +6,9 @@ import TextareaBox from '@components/TextareaBox';
 import FileInputBox from '@components/FileInputBox';
 import { boothSchema } from '@utils/schemas/adminpopup-schema';
 import ErrorPopover from '@components/ErrorPopover';
+import { useBoothStore } from '@stores/client/UseBoothStore';
 
-type BoothData = {
+export type BoothData = {
   companyName: string;
   companyType: string;
   boothLocation: string;
@@ -38,13 +39,15 @@ const AddBooth = ({
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
+  const setIsBoothRegistered = useBoothStore((state) => state.setIsBoothRegistered);
+  const setHasAggregationData = useBoothStore((state) => state.setHasAggregationData);
+
   const locationOptions = [
     { value: 'hallA', text: 'Hall A' },
     { value: 'hallB', text: 'Hall B' },
     { value: 'hallC', text: 'Hall C' },
   ];
 
-  // initialData 있을 때 상태 초기화
   useEffect(() => {
     if (initialData) {
       setCompanyName(initialData.companyName);
@@ -54,7 +57,6 @@ const AddBooth = ({
       setBoothDescription(initialData.boothDescription);
       setImageFile(initialData.imageFile);
     } else {
-      // 초기화 (수정 모드였다가 닫고 다시 열 경우 대비)
       setCompanyName('');
       setCompanyType('');
       setBoothLocation('');
@@ -80,8 +82,10 @@ const AddBooth = ({
       return;
     }
 
-    if (mode === 'add') { //TODO: api 연동 시 mode에 따라 처리
+    if (mode === 'add') {
       console.log('등록 요청', result.data);
+      setIsBoothRegistered(true);
+      setHasAggregationData(false);
     } else {
       console.log('수정 요청', result.data);
     }

--- a/src/components/AdminPage/Popup/AddSession.tsx
+++ b/src/components/AdminPage/Popup/AddSession.tsx
@@ -6,6 +6,7 @@ import TextareaBox from '@components/TextareaBox';
 import FileInputBox from '@components/FileInputBox';
 import { sessionSchema } from '@utils/schemas/adminpopup-schema';
 import ErrorPopover from '@components/ErrorPopover';
+import { useSessionStore } from '@stores/client/useSessionStore';
 
 interface AddSessionProps {
   open: boolean;
@@ -28,6 +29,8 @@ const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProp
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [maxCapacity, setMaxCapacity] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
+
+  const setSessionRegistered = useSessionStore((state) => state.setSessionRegistered);
 
   useEffect(() => {
     if (mode === 'edit' && initialData) {
@@ -83,6 +86,7 @@ const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProp
       console.log('수정 완료', result.data);
     } else {
       console.log('등록 완료', result.data);
+      setSessionRegistered(true);
     }
 
     onClose();
@@ -127,8 +131,9 @@ const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProp
         <InputBox
           label="제목"
           id="title"
-          isRequired value={title}
-          onChange={setTitle} 
+          isRequired
+          value={title}
+          onChange={setTitle}
           placeholder="세션 제목을 입력해 주세요."
         />
         <InputBox
@@ -149,7 +154,8 @@ const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProp
         />
         <InputBox
           label="진행일"
-          id="date" isRequired
+          id="date"
+          isRequired
           value={date}
           onChange={setDate}
           placeholder="진행 날짜를 입력해 주세요."
@@ -188,7 +194,8 @@ const AddSession = ({ open, onClose, mode = 'add', initialData }: AddSessionProp
         <SelectBox
           id="maxCapacity"
           label="최대 수용 인원"
-          isRequired placeholder="선택"
+          isRequired
+          placeholder="선택"
           items={capacityOptions}
           value={maxCapacity}
           onChange={setMaxCapacity}

--- a/src/components/AdminPage/Popup/AddSession.tsx
+++ b/src/components/AdminPage/Popup/AddSession.tsx
@@ -6,7 +6,7 @@ import TextareaBox from '@components/TextareaBox';
 import FileInputBox from '@components/FileInputBox';
 import { sessionSchema } from '@utils/schemas/adminpopup-schema';
 import ErrorPopover from '@components/ErrorPopover';
-import { useSessionStore } from '@stores/client/useSessionStore';
+import { useSessionStore } from '@stores/client/useSessionStore';
 
 interface AddSessionProps {
   open: boolean;

--- a/src/components/AdminPage/Popup/ConferenceForm.tsx
+++ b/src/components/AdminPage/Popup/ConferenceForm.tsx
@@ -98,7 +98,6 @@ const ConferenceForm = ({ mode, open, onClose, onSubmit, initialData }: Conferen
     }
 
     onSubmit(result.data);
-    onClose();
   };
 
   return (

--- a/src/components/AdminPage/Popup/LevelRanking.tsx
+++ b/src/components/AdminPage/Popup/LevelRanking.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Button,
+  Typography,
+  Box,
+  IconButton,
+  useTheme,
+  css,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
+
+interface LevelRankingProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const dummyData = [
+  { rank: 'PT', name: '김구름', points: '000', level: '플래티넘' },
+  { rank: 'PT', name: '박푸디', points: '000', level: '플래티넘' },
+  { rank: 'GD', name: '이사과', points: '000', level: '골드' },
+  { rank: 'GD', name: '최딸기', points: '000', level: '골드' },
+  { rank: 'SV', name: '홍수박', points: '000', level: '실버' },
+  { rank: 'BZ', name: '강블루', points: '000', level: '브론즈' },
+];
+
+const LevelRanking = ({ open, onClose }: LevelRankingProps) => {
+  const { palette, typo } = useTheme();
+  const [selectedLevel, setSelectedLevel] = useState<string | null>(null);
+
+  const handleFilterClick = (level: string) => {
+    setSelectedLevel((prev) => (prev === level ? null : level));
+  };
+
+  const filteredData = selectedLevel
+    ? dummyData.filter((item) => item.level === selectedLevel)
+    : dummyData;
+
+  const filterButtons = ['플래티넘', '골드', '실버', '브론즈'];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          width: '400px',
+          height: '600px',
+          borderRadius: '18px',
+          display: 'flex',
+          flexDirection: 'column',
+        },
+      }}
+    >
+      <DialogTitle
+        css={css`
+          font-family: ${typo.fontFamily.Pretendard};
+          font-size: 20px;
+          font-weight: bold;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        `}
+      >
+        등급별 참가자 랭킹 상세
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon sx={{ color: palette.border.secondary }} />
+        </IconButton>
+      </DialogTitle>
+      <Box
+        css={css`
+          background-color: ${palette.background.tertiary};
+          padding: 16px 24px 0;
+          flex-shrink: 0;
+        `}
+      >
+        <Box display="flex" gap="24px" mb="12px" flexWrap="wrap">
+          {filterButtons.map((level) => {
+            const isSelected = selectedLevel === level;
+            return (
+              <Button
+                key={level}
+                variant={isSelected ? 'contained' : 'outlined'}
+                size="small"
+                onClick={() => handleFilterClick(level)}
+                css={css`
+                  border-radius: 18px;
+                  background-color: ${palette.background.quaternary};
+                  color: ${palette.text.primary};
+                  border: none;
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                  align-self: stretch;
+                  gap: 4px;
+                `}
+              >
+                {level}
+                <CheckCircleOutlinedIcon
+                  sx={{
+                    fontSize: '14px',
+                    color: isSelected
+                      ? palette.icon.tertiary
+                      : palette.icon.primary,
+                  }}
+                />
+              </Button>
+            );
+          })}
+        </Box>
+      </Box>
+      <DialogContent
+        css={css`
+          background-color: ${palette.background.tertiary};
+          padding: 0 24px 24px;
+          overflow-y: auto;
+          flex-grow: 1;
+        `}
+      >
+        <Box
+          display="grid"
+          gridTemplateColumns="0.7fr 0.9fr 0.9fr 0.5fr"
+          mb="4px"
+          fontWeight="bold"
+          color={palette.text.primary}
+          fontSize="14px"
+        >
+          <span>등급</span>
+          <span>참가자 이름</span>
+          <span>누적 포인트</span>
+          <span>상세 정보</span>
+        </Box>
+        <Box
+            height="1px"
+            width="100%"
+            bgcolor={palette.border.secondary}
+            mb="8px"
+        />
+        {filteredData.map((item, idx) => (
+          <Box
+            key={idx}
+            display="grid"
+            gridTemplateColumns="1fr 1fr 1fr auto"
+            alignItems="center"
+            py="6px"
+          >
+            <Typography fontSize="13px">{item.rank}</Typography>
+            <Typography fontSize="13px">{item.name}</Typography>
+            <Typography fontSize="13px">{item.points}</Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              css={css`
+                border-radius: 18px;
+                font-size: 12px;
+                padding: 2px 10px;
+                color: ${palette.text.primary};
+                background-color: ${palette.background.quaternary};
+                border-color: ${palette.divider_custom.primary};
+                min-width: auto;
+              `}
+            >
+              열람
+            </Button>
+          </Box>
+        ))}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default LevelRanking;

--- a/src/components/AdminPage/Popup/PointLanking.tsx
+++ b/src/components/AdminPage/Popup/PointLanking.tsx
@@ -1,0 +1,109 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+  Box,
+  IconButton,
+  useTheme,
+  css,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+interface PointRankingProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const dummyPointData = [
+  { rank: 1, name: '김구름', points: '000' },
+  { rank: 1, name: '박푸디', points: '000' },
+  { rank: 1, name: '이사과', points: '000' },
+  { rank: 1, name: '최딸기', points: '000' },
+  { rank: 1, name: '홍수박', points: '000' },
+  { rank: 1, name: '강블루', points: '000' },
+  { rank: 1, name: '하초코', points: '000' },
+  { rank: 1, name: '문라떼', points: '000' },
+  { rank: 1, name: '이프디', points: '000' },
+  { rank: 1, name: '최프디', points: '000' },
+  { rank: 1, name: '김프디', points: '000' },
+  { rank: 1, name: '박프디', points: '000' },
+  { rank: 1, name: '정프디', points: '000' },
+  { rank: 1, name: '주프디', points: '000' },
+];
+
+const PointRanking = ({ open, onClose }: PointRankingProps) => {
+  const { palette, typo } = useTheme();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          width: '400px',
+          height: '600px',
+          borderRadius: '18px',
+          display: 'flex',
+          flexDirection: 'column',
+        },
+      }}
+    >
+      <DialogTitle
+        css={css`
+          font-family: ${typo.fontFamily.Pretendard};
+          font-size: 20px;
+          font-weight: bold;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        `}
+      >
+        누적 포인트 랭킹 상세
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon sx={{ color: palette.border.secondary }} />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent
+        css={css`
+          background-color: ${palette.background.tertiary};
+          padding: 16px 24px 24px;
+          overflow-y: auto;
+          flex-grow: 1;
+        `}
+      >
+        <Box
+          display="grid"
+          gridTemplateColumns="1fr 1fr auto"
+          mb="4px"
+          fontWeight="bold"
+          color={palette.text.primary}
+          fontSize="14px"
+        >
+          <span>순위</span>
+          <span>참가자 이름</span>
+          <span>누적 포인트</span>
+        </Box>
+        <Box height="1px" width="100%" bgcolor={palette.border.secondary} mb="8px" />
+        {dummyPointData.map((item, idx) => (
+          <Box
+            key={idx}
+            display="grid"
+            gridTemplateColumns="1fr 1fr auto"
+            alignItems="center"
+            py="6px"
+          >
+            <Typography fontSize="13px">{item.rank}</Typography>
+            <Typography fontSize="13px">{item.name}</Typography>
+            <Typography fontSize="13px">{item.points}</Typography>
+          </Box>
+        ))}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default PointRanking;

--- a/src/components/AdminPage/RegButtons.tsx
+++ b/src/components/AdminPage/RegButtons.tsx
@@ -1,11 +1,16 @@
 import { useState } from 'react';
-import { Box, Button, Modal, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import ConferenceForm from './Popup/ConferenceForm';
+import { useConferenceStore } from '@stores/client/useConferenceStore';
 
-const ConferenceRegistration = () => {
+interface ConferenceRegistrationProps {
+  onRegister?: () => void;
+}
+
+const ConferenceRegistration = ({ onRegister = () => {} }: ConferenceRegistrationProps) => {
   const { palette, typography, radius } = useTheme();
   const [isConferenceRegistered, setIsConferenceRegistered] = useState(false);
   const [open, setOpen] = useState(false);
@@ -23,7 +28,6 @@ const ConferenceRegistration = () => {
 
   const handleModify = () => {
     if (isConferenceRegistered) {
-      // 임시 데이터로 초기값 세팅 (실제 데이터는 API에서 가져오거나 state로 관리)
       const dummyData = {
         name: '샘플 컨퍼런스',
         host: '주최자',
@@ -46,8 +50,10 @@ const ConferenceRegistration = () => {
 
   const handleModalSubmit = (data: any) => {
     console.log('등록 또는 수정 완료:', data);
+    useConferenceStore.getState().setConferenceRegistered(true);
     setIsConferenceRegistered(true);
     handleClose();
+    onRegister();
   };
 
   const buttonStyle = css`
@@ -115,22 +121,13 @@ const ConferenceRegistration = () => {
           컨퍼런스 수정
         </Typography>
       </Button>
-
-      <Modal
+      <ConferenceForm
+        mode={mode}
         open={open}
         onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
-        disableEnforceFocus
-      >
-        <ConferenceForm
-          mode={mode}
-          open={open}
-          onClose={handleClose}
-          onSubmit={handleModalSubmit}
-          initialData={conferenceData}
-        />
-      </Modal>
+        onSubmit={handleModalSubmit}
+        initialData={conferenceData}
+      />
     </Box>
   );
 };

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -4,7 +4,7 @@ import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import AddSession from './Popup/AddSession';
 import { useConferenceStore } from '@stores/client/useConferenceStore';
-import { useSessionStore } from '@stores/client/useSessionStore'; 
+import { useSessionStore } from '@stores/client/useSessionStore'; 
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -1,58 +1,129 @@
+import { useState } from 'react';
 import { Box, Typography, Paper } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import AddSession from './Popup/AddSession';
+import { useConferenceStore } from '@stores/client/useConferenceStore';
+import { useSessionStore } from '@stores/client/useSessionStore'; 
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { useNavigate } from 'react-router-dom';
 
 const SessionParticipation = () => {
     const { palette, typography, radius } = useTheme();
+    const isConferenceRegistered = useConferenceStore((state) => state.isConferenceRegistered);
+    const { isSessionRegistered, hasAggregationData } = useSessionStore(); 
+    const [showAddSession, setShowAddSession] = useState(false);
+    const navigate = useNavigate();
+
+    const handleAddIconClick = () => {
+        if (isConferenceRegistered) {
+            setShowAddSession(true);
+        } else {
+            alert('컨퍼런스를 등록해주세요');
+        }
+    };
+
+    const handleChevronClick = () => {
+        if (isConferenceRegistered) {
+            navigate('/admin/session');
+        } else {
+            alert('컨퍼런스를 등록해주세요');
+        }
+    };
+
     return (
-        <Box>
-            <Typography 
-                variant="subtitle1" 
-                fontWeight="bold" 
-                mb={1}
-                css={css`
-                    color: ${palette.text.primary};
-                    font-family: ${typography.fontFamily};
-                `}
-            >
-                세션 참여 현황
-            </Typography>
-            <Paper
-                css={css`
-                    text-align: center;
-                    color: ${palette.text.secondary};
-                    border-radius: ${radius.sm}px;
-                    background-color: ${palette.background.secondary};
-                    padding: 50px;
-                    border: ${palette.divider_custom.primary};
-                `}
-            >
-                <AddIcon 
+        <Box position="relative">
+            <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                <Typography 
+                    variant="subtitle1" 
+                    fontWeight="bold"
                     css={css`
-                        font-size: 40px;
-                        color: ${palette.text.secondary};
-                        margin-bottom: 16px;
+                        color: ${palette.text.primary};
+                        font-family: ${typography.fontFamily};
                     `}
+                >
+                    세션 참여 현황
+                </Typography>
+                <ChevronRightIcon 
+                    css={css`
+                        color: ${palette.icon.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleChevronClick}
                 />
-                <Typography 
-                    variant="body2"
+            </Box>
+
+            {!isConferenceRegistered ? (
+                <Paper
                     css={css`
+                        text-align: center;
                         color: ${palette.text.secondary};
-                        font-family: ${typography.fontFamily};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleAddIconClick}
+                >
+                    <AddIcon 
+                        css={css`
+                            font-size: 40px;
+                            color: ${palette.text.secondary};
+                            margin-bottom: 16px;
+                        `}
+                    />
+                    <Typography variant="body2">등록된 세션이 없습니다.</Typography>
+                    <Typography variant="body2">컨퍼런스 등록 후 확인 가능합니다.</Typography>
+                </Paper>
+            ) : !isSessionRegistered ? (
+                <Paper
+                    css={css`
+                        text-align: center;
+                        color: ${palette.text.secondary};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
+                        cursor: pointer;
+                    `}
+                    onClick={handleAddIconClick}
+                >
+                    <AddIcon 
+                        css={css`
+                            font-size: 40px;
+                            color: ${palette.text.secondary};
+                            margin-bottom: 16px;
+                        `}
+                    />
+                    <Typography variant="body2">등록된 세션이 없습니다.</Typography>
+                    <Typography variant="body2">세션 등록 후 확인 가능합니다.</Typography>
+                </Paper>
+            ) : !hasAggregationData ? (
+                <Paper
+                    css={css`
+                        text-align: center;
+                        color: ${palette.text.secondary};
+                        border-radius: ${radius.sm}px;
+                        background-color: ${palette.background.secondary};
+                        padding: 50px;
+                        border: ${palette.divider_custom.primary};
                     `}
                 >
-                    등록된 세션이 없습니다.
-                </Typography>
-                <Typography 
-                    variant="body2"
-                    css={css`
-                        color: ${palette.text.secondary};
-                        font-family: ${typography.fontFamily};
-                    `}
-                >
-                    컨퍼런스 등록 후 확인 가능합니다.
-                </Typography>
-            </Paper>
+                    <Typography variant="body2" mb={1}>
+                        집계된 정보가 없습니다.
+                    </Typography>
+                </Paper>
+            ) : (
+                <Typography>집계된 세션 정보 표시</Typography>
+            )}
+
+            {showAddSession && (
+                <AddSession 
+                    open={showAddSession}
+                    onClose={() => setShowAddSession(false)}
+                />
+            )}
         </Box>
     );
 };

--- a/src/stores/client/useBoothStore.ts
+++ b/src/stores/client/useBoothStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface BoothStoreState {
+    isBoothRegistered: boolean;
+    hasAggregationData: boolean;
+    setIsBoothRegistered: (registered: boolean) => void;
+    setHasAggregationData: (hasData: boolean) => void;
+}
+
+export const useBoothStore = create<BoothStoreState>((set) => ({
+    isBoothRegistered: false,
+    hasAggregationData: false,
+    setIsBoothRegistered: (registered) => set({ isBoothRegistered: registered }),
+    setHasAggregationData: (hasData) => set({ hasAggregationData: hasData }),
+}));

--- a/src/stores/client/useConferenceStore.ts
+++ b/src/stores/client/useConferenceStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ConferenceStore {
+  isConferenceRegistered: boolean;
+  setConferenceRegistered: (registered: boolean) => void;
+}
+
+export const useConferenceStore = create<ConferenceStore>((set) => ({
+  isConferenceRegistered: false,
+  setConferenceRegistered: (registered) => set({ isConferenceRegistered: registered }),
+}));

--- a/src/stores/client/useSessionStore.ts
+++ b/src/stores/client/useSessionStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface SessionStore {
+  isSessionRegistered: boolean;
+  hasAggregationData: boolean;
+  setSessionRegistered: (registered: boolean) => void;
+  setAggregationData: (hasData: boolean) => void;
+}
+
+export const useSessionStore = create<SessionStore>((set) => ({
+  isSessionRegistered: false,
+  hasAggregationData: false,
+  setSessionRegistered: (registered) => set({ isSessionRegistered: registered }),
+  setAggregationData: (hasData) => set({ hasAggregationData: hasData }),
+}));


### PR DESCRIPTION

## 🚀 반영 브랜치

`feat/dashboard` → `dev`

<br/>

## ✅ 작업 내용

- 컨퍼런스 등록 전 : 컨퍼런스 등록해야만 세션, 부스 등록 가능 
- 컨퍼런스 등록 후 : + 아이콘 통해서 세션, 부스 등록 가능, 안내문 달라짐, 상세 페이지 이동 가능
- 세션, 부스 등록 후 : 집계된 정보 없음 화면 
- 등급, 포인트 각 랭킹 팝업 구현

<br/>

## 🌠 이미지 첨부


https://github.com/user-attachments/assets/0e150b4b-0373-4b7c-b003-659424784441



<br/>

## ✏️ 앞으로의 과제

- 헤더 고정
- qr, 사용자 상세 정보 팝업 구현
- 컨퍼런스 등록 전 + 아이콘 클릭 시 컨퍼런스 등록 모달 띄우기 

<br/>


