### PR TITLE
feat(admin): 관리자 페이지 추가 구현

### DIFF
--- a/src/components/AdminPage/BoothBox.tsx
+++ b/src/components/AdminPage/BoothBox.tsx
@@ -5,6 +5,7 @@ import QrCodeIcon from '@mui/icons-material/QrCode';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+import QRPopup from './Popup/QRPopup';
 
 interface BoothBoxProps {
   date: string;
@@ -19,7 +20,8 @@ interface BoothBoxProps {
 const BoothBox = ({ date, place, title, category, onDelete, onEdit }: BoothBoxProps) => {
   const theme = useTheme();
   const { palette, spacing, typo } = theme;
-  const [open, setOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [qrPopupOpen, setQrPopupOpen] = useState(false);
 
   const boxStyle = css`
     position: relative;
@@ -50,23 +52,29 @@ const BoothBox = ({ date, place, title, category, onDelete, onEdit }: BoothBoxPr
   return (
     <Box css={boxStyle}>
       <ConfirmDeleteDialog
-        open={open}
+        open={deleteDialogOpen}
         title="부스를 삭제하시겠습니까?"
         description="부스 삭제 시 복구가 불가능합니다."
-        onClose={() => setOpen(false)}
+        onClose={() => setDeleteDialogOpen(false)}
         onConfirm={() => {
           onDelete();
-          setOpen(false);
+          setDeleteDialogOpen(false);
         }}
       />
+      <QRPopup
+          open={qrPopupOpen}
+          onClose={() => setQrPopupOpen(false)}
+          qrCodeLabel={title}
+          description={place}
+        />
       <Box css={iconContainerStyle}>
-        <IconButton size="small" color="inherit">
+        <IconButton size="small" color="inherit" onClick={() => setQrPopupOpen(true)}>
           <QrCodeIcon fontSize="small" />
         </IconButton>
         <IconButton size="small" color="inherit" onClick={onEdit}>
           <EditIcon fontSize="small" />
         </IconButton>
-        <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>
+        <IconButton size="small" color="inherit" onClick={() => setDeleteDialogOpen(true)}>
           <DeleteIcon fontSize="small" />
         </IconButton>
       </Box>

--- a/src/components/AdminPage/BoothParticipation.tsx
+++ b/src/components/AdminPage/BoothParticipation.tsx
@@ -7,19 +7,21 @@ import { useConferenceStore } from '@stores/client/useConferenceStore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useNavigate } from 'react-router-dom';
 import { useBoothStore } from '@stores/client/useBoothStore';
+import ConferenceForm from './Popup/ConferenceForm';
 
 const BoothParticipation = () => {
     const { palette, typography, radius } = useTheme();
     const isConferenceRegistered = useConferenceStore((state) => state.isConferenceRegistered);
     const { isBoothRegistered, hasAggregationData } = useBoothStore();
     const [showAddBooth, setShowAddBooth] = useState(false);
+    const [showAddConference, setShowAddConference] = useState(false);
     const navigate = useNavigate();
 
     const handleAddIconClick = () => {
         if (isConferenceRegistered) {
             setShowAddBooth(true);
         } else {
-            alert('컨퍼런스를 등록해주세요');
+            setShowAddConference(true);
         }
     };
 
@@ -29,6 +31,11 @@ const BoothParticipation = () => {
         } else {
             alert('컨퍼런스를 등록해주세요');
         }
+    };
+
+    const handleConferenceSubmit = (data: any) => {
+        console.log('컨퍼런스 등록 완료:', data);
+        setShowAddConference(false);
     };
 
     return (
@@ -122,6 +129,14 @@ const BoothParticipation = () => {
                 <AddBooth
                     open={showAddBooth}
                     onClose={() => setShowAddBooth(false)}
+                />
+            )}
+            {showAddConference && (
+                <ConferenceForm
+                    mode="add"
+                    open={showAddConference}
+                    onClose={() => setShowAddConference(false)}
+                    onSubmit={handleConferenceSubmit}
                 />
             )}
         </Box>

--- a/src/components/AdminPage/Popup/LevelRanking.tsx
+++ b/src/components/AdminPage/Popup/LevelRanking.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
+import UserInfo from './UserInfo';
 
 interface LevelRankingProps {
   open: boolean;
@@ -30,6 +31,7 @@ const dummyData = [
 const LevelRanking = ({ open, onClose }: LevelRankingProps) => {
   const { palette, typo } = useTheme();
   const [selectedLevel, setSelectedLevel] = useState<string | null>(null);
+  const [userInfoOpen, setUserInfoOpen] = useState(false);
 
   const handleFilterClick = (level: string) => {
     setSelectedLevel((prev) => (prev === level ? null : level));
@@ -42,136 +44,142 @@ const LevelRanking = ({ open, onClose }: LevelRankingProps) => {
   const filterButtons = ['플래티넘', '골드', '실버', '브론즈'];
 
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      PaperProps={{
-        sx: {
-          width: '400px',
-          height: '600px',
-          borderRadius: '18px',
-          display: 'flex',
-          flexDirection: 'column',
-        },
-      }}
-    >
-      <DialogTitle
-        css={css`
-          font-family: ${typo.fontFamily.Pretendard};
-          font-size: 20px;
-          font-weight: bold;
-          color: ${palette.text.primary};
-          background-color: ${palette.background.tertiary};
-          padding: 24px;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-        `}
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        PaperProps={{
+          sx: {
+            width: '400px',
+            height: '600px',
+            borderRadius: '18px',
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        }}
       >
-        등급별 참가자 랭킹 상세
-        <IconButton onClick={onClose} size="small">
-          <CloseIcon sx={{ color: palette.border.secondary }} />
-        </IconButton>
-      </DialogTitle>
-      <Box
-        css={css`
-          background-color: ${palette.background.tertiary};
-          padding: 16px 24px 0;
-          flex-shrink: 0;
-        `}
-      >
-        <Box display="flex" gap="24px" mb="12px" flexWrap="wrap">
-          {filterButtons.map((level) => {
-            const isSelected = selectedLevel === level;
-            return (
-              <Button
-                key={level}
-                variant={isSelected ? 'contained' : 'outlined'}
-                size="small"
-                onClick={() => handleFilterClick(level)}
-                css={css`
-                  border-radius: 18px;
-                  background-color: ${palette.background.quaternary};
-                  color: ${palette.text.primary};
-                  border: none;
-                  display: flex;
-                  align-items: center;
-                  justify-content: space-between;
-                  align-self: stretch;
-                  gap: 4px;
-                `}
-              >
-                {level}
-                <CheckCircleOutlinedIcon
-                  sx={{
-                    fontSize: '14px',
-                    color: isSelected
-                      ? palette.icon.tertiary
-                      : palette.icon.primary,
-                  }}
-                />
-              </Button>
-            );
-          })}
-        </Box>
-      </Box>
-      <DialogContent
-        css={css`
-          background-color: ${palette.background.tertiary};
-          padding: 0 24px 24px;
-          overflow-y: auto;
-          flex-grow: 1;
-        `}
-      >
-        <Box
-          display="grid"
-          gridTemplateColumns="0.7fr 0.9fr 0.9fr 0.5fr"
-          mb="4px"
-          fontWeight="bold"
-          color={palette.text.primary}
-          fontSize="14px"
+        <DialogTitle
+          css={css`
+            font-family: ${typo.fontFamily.Pretendard};
+            font-size: 20px;
+            font-weight: bold;
+            color: ${palette.text.primary};
+            background-color: ${palette.background.tertiary};
+            padding: 24px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          `}
         >
-          <span>등급</span>
-          <span>참가자 이름</span>
-          <span>누적 포인트</span>
-          <span>상세 정보</span>
-        </Box>
+          등급별 참가자 랭킹 상세
+          <IconButton onClick={onClose} size="small">
+            <CloseIcon sx={{ color: palette.border.secondary }} />
+          </IconButton>
+        </DialogTitle>
         <Box
+          css={css`
+            background-color: ${palette.background.tertiary};
+            padding: 16px 24px 0;
+            flex-shrink: 0;
+          `}
+        >
+          <Box display="flex" gap="24px" mb="12px" flexWrap="wrap">
+            {filterButtons.map((level) => {
+              const isSelected = selectedLevel === level;
+              return (
+                <Button
+                  key={level}
+                  variant={isSelected ? 'contained' : 'outlined'}
+                  size="small"
+                  onClick={() => handleFilterClick(level)}
+                  css={css`
+                    border-radius: 18px;
+                    background-color: ${palette.background.quaternary};
+                    color: ${palette.text.primary};
+                    border: none;
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    align-self: stretch;
+                    gap: 4px;
+                  `}
+                >
+                  {level}
+                  <CheckCircleOutlinedIcon
+                    sx={{
+                      fontSize: '14px',
+                      color: isSelected
+                        ? palette.icon.tertiary
+                        : palette.icon.primary,
+                    }}
+                  />
+                </Button>
+              );
+            })}
+          </Box>
+        </Box>
+        <DialogContent
+          css={css`
+            background-color: ${palette.background.tertiary};
+            padding: 0 24px 24px;
+            overflow-y: auto;
+            flex-grow: 1;
+          `}
+        >
+          <Box
+            display="grid"
+            gridTemplateColumns="0.7fr 0.9fr 0.9fr 0.5fr"
+            mb="4px"
+            fontWeight="bold"
+            color={palette.text.primary}
+            fontSize="14px"
+          >
+            <span>등급</span>
+            <span>참가자 이름</span>
+            <span>누적 포인트</span>
+            <span>상세 정보</span>
+          </Box>
+          <Box
             height="1px"
             width="100%"
             bgcolor={palette.border.secondary}
             mb="8px"
-        />
-        {filteredData.map((item, idx) => (
-          <Box
-            key={idx}
-            display="grid"
-            gridTemplateColumns="1fr 1fr 1fr auto"
-            alignItems="center"
-            py="6px"
-          >
-            <Typography fontSize="13px">{item.rank}</Typography>
-            <Typography fontSize="13px">{item.name}</Typography>
-            <Typography fontSize="13px">{item.points}</Typography>
-            <Button
-              variant="outlined"
-              size="small"
-              css={css`
-                border-radius: 18px;
-                font-size: 12px;
-                padding: 2px 10px;
-                color: ${palette.text.primary};
-                background-color: ${palette.background.quaternary};
-                border-color: ${palette.divider_custom.primary};
-                min-width: auto;
-              `}
+          />
+          {filteredData.map((item, idx) => (
+            <Box
+              key={idx}
+              display="grid"
+              gridTemplateColumns="1fr 1fr 1fr auto"
+              alignItems="center"
+              py="6px"
             >
-              열람
-            </Button>
-          </Box>
-        ))}
-      </DialogContent>
-    </Dialog>
+              <Typography fontSize="13px">{item.rank}</Typography>
+              <Typography fontSize="13px">{item.name}</Typography>
+              <Typography fontSize="13px">{item.points}</Typography>
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => setUserInfoOpen(true)}
+                css={css`
+                  border-radius: 18px;
+                  font-size: 12px;
+                  padding: 2px 10px;
+                  color: ${palette.text.primary};
+                  background-color: ${palette.background.quaternary};
+                  border-color: ${palette.divider_custom.primary};
+                  min-width: auto;
+                `}
+              >
+                열람
+              </Button>
+            </Box>
+          ))}
+        </DialogContent>
+      </Dialog>
+
+      {/* ✅ UserInfo 팝업 연결 */}
+      <UserInfo open={userInfoOpen} onClose={() => setUserInfoOpen(false)} />
+    </>
   );
 };
 

--- a/src/components/AdminPage/Popup/QRPopup.tsx
+++ b/src/components/AdminPage/Popup/QRPopup.tsx
@@ -1,0 +1,87 @@
+import { Dialog, DialogContent, IconButton, Typography, Box } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { css, useTheme } from '@mui/material';
+
+interface QRPopupProps {
+    open: boolean;
+    onClose: () => void;
+    qrCodeLabel: string; // QR 코드 아래 1
+    description: string; // QR 코드 아래 2
+}
+
+const QRPopup = ({ open, onClose, qrCodeLabel, description }: QRPopupProps) => {
+    const { palette, typography } = useTheme();
+
+    return (
+        <Dialog 
+            open={open} 
+            onClose={onClose} 
+            maxWidth="xs" 
+            fullWidth
+            PaperProps={{
+                sx: {
+                    maxWidth: 400,
+                    borderRadius: 4,
+                    backgroundColor: palette.background.tertiary,
+                    position: 'relative',
+                },
+            }}
+        >
+            <IconButton 
+                onClick={onClose} 
+                sx={{
+                    position: 'absolute', 
+                    top: 8,
+                    right: 8,
+                    color: palette.icon.primary,
+                }}
+            >
+                <CloseIcon />
+            </IconButton>
+            <DialogContent>
+                <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center">
+                    <Box //qr 자리 확인을 위한 박스
+                        width={150}
+                        height={150}
+                        css={css`
+                            border: 1px solid ${palette.divider};
+                        `}
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                    >
+                        {/* QR 이미지 자리 */}
+                        <Box
+                            width={150}
+                            height={150}
+                            css={css`
+                                background-color: ${palette.divider};
+                            `}
+                        />
+                    </Box>
+                    <Typography 
+                        mt={2} 
+                        fontWeight="bold" 
+                        css={css`
+                            font-family: ${typography.fontFamily};
+                            color: ${palette.text.primary};
+                        `}
+                    >
+                        {qrCodeLabel}
+                    </Typography>
+                    <Typography 
+                        variant="body2" 
+                        css={css`
+                            color: ${palette.text.secondary};
+                            font-family: ${typography.fontFamily};
+                        `}
+                    >
+                        {description}
+                    </Typography>
+                </Box>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default QRPopup;

--- a/src/components/AdminPage/Popup/UserInfo.tsx
+++ b/src/components/AdminPage/Popup/UserInfo.tsx
@@ -1,0 +1,107 @@
+import { Dialog, DialogContent, Box, IconButton, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { css, useTheme } from '@mui/material';
+
+interface UserInfoProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const UserInfo = ({ open, onClose }: UserInfoProps) => {
+  const theme = useTheme();
+  const { palette, typography } = theme;
+
+  const dialogPaperStyle = css`
+    min-width: 400px;
+    min-height: 600px;
+    border-radius: 16px;
+    background-color: ${palette.background.tertiary};
+    overflow: hidden;
+  `;
+
+  const headerStyle = css`
+    position: relative;
+    padding: 16px;
+    border-bottom: 1px solid ${palette.divider};
+    flex-shrink: 0;
+    background-color: ${palette.background.tertiary}
+  `;
+
+  const titleStyle = css`
+    font-family: ${typography.fontFamily};
+    font-weight: bold;
+    color: ${palette.text.primary};
+  `;
+
+  const closeIconStyle = css`
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    color: ${palette.icon.primary}
+  `;
+
+  const contentStyle = css`
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    background-color: ${palette.background.tertiary}
+  `;
+
+  const sectionStyle = css`
+    margin-bottom: 16px;
+  `;
+
+  const sectionTitleStyle = css`
+    font-weight: bold;
+    margin-bottom: 8px;
+    color: ${palette.text.primary};
+  `;
+
+  const contentTextStyle = css`
+    color: ${palette.text.secondary};
+    line-height: 1.5;
+  `;
+
+  const userInfoData = [
+    { title: '학력', content: '4년제 대학 졸업' },
+    { title: '연령대', content: '20 ~ 24세 이하' },
+    {
+      title: '보유 기술',
+      content:
+        'Java, Spring Boot, MySQL, Docker, JPA, Github Actions, SonarQube, Redis, Junit5, Mockito, Git',
+    },
+    {
+      title: '자기소개',
+      content:
+        '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 프로젝트에 참여하며 역량을 쌓아왔습니다. 데이터베이스 설계 경험이 있으며 협업과 문제 해결 능력을 갖추고 있습니다. 앞으로도 꾸준히 배우며 성장하겠습니다.',
+    },
+  ];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth={false}
+      PaperProps={{
+        css: dialogPaperStyle,
+      }}
+    >
+      <Box css={headerStyle}>
+        <Typography css={titleStyle}>사용자 상세 정보</Typography>
+        <IconButton onClick={onClose} css={closeIconStyle}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <DialogContent css={contentStyle}>
+        {userInfoData.map((item, idx) => (
+          <Box key={idx} css={sectionStyle}>
+            <Typography css={sectionTitleStyle}>{item.title}</Typography>
+            <Typography css={contentTextStyle}>{item.content}</Typography>
+          </Box>
+        ))}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default UserInfo;

--- a/src/components/AdminPage/SessionBox.tsx
+++ b/src/components/AdminPage/SessionBox.tsx
@@ -5,6 +5,7 @@ import QrCodeIcon from '@mui/icons-material/QrCode';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
+import QRPopup from './Popup/QRPopup';
 
 interface SessionBoxProps {
   date: string;
@@ -20,7 +21,8 @@ interface SessionBoxProps {
 const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: SessionBoxProps) => {
   const theme = useTheme();
   const { palette, spacing, typo } = theme;
-  const [open, setOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [qrPopupOpen, setQrPopupOpen] = useState(false);
 
   const boxStyle = css`
     position: relative;
@@ -42,44 +44,53 @@ const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: Ses
   const iconContainerStyle = css`
     color: ${palette.icon.primary};
     position: absolute;
-    top: 8px;           
-    right: 8px;        
+    top: 8px;
+    right: 8px;
     display: flex;
-    gap: 2px;   
+    gap: 2px;
   `;
 
   return (
-    <Box css={boxStyle}>
-      <ConfirmDeleteDialog
-        open={open}
-        title="세션을 삭제하시겠습니까?"
-        description="세션 삭제 시 복구가 불가능합니다."
-        onClose={() => setOpen(false)}
-        onConfirm={() => {
-          onDelete();
-          setOpen(false);
-        }}
-      />
-      <Box css={iconContainerStyle}>
-        <IconButton size="small" color="inherit">
-          <QrCodeIcon fontSize="small" />
-        </IconButton>
-        <IconButton size="small" color="inherit" onClick={onEdit}>
-          <EditIcon fontSize="small" />
-        </IconButton>
-        <IconButton size="small" color="inherit" onClick={() => setOpen(true)}>
-          <DeleteIcon fontSize="small" />
-        </IconButton>
+    <>
+      <Box css={boxStyle}>
+        <ConfirmDeleteDialog
+          open={deleteDialogOpen}
+          title="세션을 삭제하시겠습니까?"
+          description="세션 삭제 시 복구가 불가능합니다."
+          onClose={() => setDeleteDialogOpen(false)}
+          onConfirm={() => {
+            onDelete();
+            setDeleteDialogOpen(false);
+          }}
+        />
+        <QRPopup
+          open={qrPopupOpen}
+          onClose={() => setQrPopupOpen(false)}
+          qrCodeLabel={title}
+          description={speaker}
+        />
+
+        <Box css={iconContainerStyle}>
+          <IconButton size="small" color="inherit" onClick={() => setQrPopupOpen(true)}>
+            <QrCodeIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small" color="inherit" onClick={onEdit}>
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small" color="inherit" onClick={() => setDeleteDialogOpen(true)}>
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Box>
+
+        {/* 정보 영역 */}
+        <Typography css={infoStyle}>{date} {place}</Typography>
+        <Typography css={infoStyle}>{time}</Typography>
+        <Typography css={infoStyle}>{title} {speaker}</Typography>
+
+        {/* 차트 데이터 영역 */}
+        <Typography variant="body2">!차트 데이터 표시 영역!</Typography>
       </Box>
-
-      {/* 정보 영역 */}
-      <Typography css={infoStyle}>{date} {place}</Typography>
-      <Typography css={infoStyle}>{time}</Typography>
-      <Typography css={infoStyle}>{title} {speaker}</Typography>
-
-      {/* 차트 데이터 영역 */}
-      <Typography variant="body2"> !차트 데이터 표시 영역!</Typography>
-    </Box>
+    </>
   );
 };
 

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -7,19 +7,21 @@ import { useConferenceStore } from '@stores/client/useConferenceStore';
 import { useSessionStore } from '@stores/client/useSessionStore'; 
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useNavigate } from 'react-router-dom';
+import ConferenceForm from './Popup/ConferenceForm';
 
 const SessionParticipation = () => {
     const { palette, typography, radius } = useTheme();
     const isConferenceRegistered = useConferenceStore((state) => state.isConferenceRegistered);
     const { isSessionRegistered, hasAggregationData } = useSessionStore(); 
     const [showAddSession, setShowAddSession] = useState(false);
+    const [showAddConference, setShowAddConference] = useState(false);
     const navigate = useNavigate();
 
     const handleAddIconClick = () => {
         if (isConferenceRegistered) {
             setShowAddSession(true);
         } else {
-            alert('컨퍼런스를 등록해주세요');
+            setShowAddConference(true);
         }
     };
 
@@ -29,6 +31,10 @@ const SessionParticipation = () => {
         } else {
             alert('컨퍼런스를 등록해주세요');
         }
+    };
+    const handleConferenceSubmit = (data: any) => {
+        console.log('컨퍼런스 등록 완료:', data);
+        setShowAddConference(false);
     };
 
     return (
@@ -122,6 +128,14 @@ const SessionParticipation = () => {
                 <AddSession 
                     open={showAddSession}
                     onClose={() => setShowAddSession(false)}
+                />
+            )}
+            {showAddConference && (
+                <ConferenceForm
+                    mode="add"
+                    open={showAddConference}
+                    onClose={() => setShowAddConference(false)}
+                    onSubmit={handleConferenceSubmit}
                 />
             )}
         </Box>

--- a/src/components/headers/AdminHeader.tsx
+++ b/src/components/headers/AdminHeader.tsx
@@ -1,0 +1,72 @@
+import { useNavigate } from 'react-router-dom';
+import { Box, Typography, Button } from '@mui/material';
+import { css, useTheme } from '@mui/material/styles';
+import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
+import { typography } from '@styles/foundation';
+
+const Header = () => {
+  const theme = useTheme();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    // TODO: 로그아웃 로직
+    navigate('/role-selection');
+  };
+
+  const headerWrapperStyle = css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 999;
+  `;
+
+  const headerInnerStyle = css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    max-width: 600px;
+    width: 100%;
+    margin: 0 auto;
+    background-color: ${theme.palette.background.primary};
+    padding: ${theme.spacing(2)} 1rem;
+  `;
+
+  const logoStyle = css`
+    font-weight: 800;
+    font-size: 28px;
+    font-family: ${typography.fontFamily.Montserrat};
+    color: ${theme.palette.text.primary};
+  `;
+
+  const logoutButtonStyle = css`
+    background-color: ${theme.palette.background.quaternary};
+    color: ${theme.palette.text.primary};
+    border-radius: 18px;
+    padding: 8px 16px;
+    border: none;
+    .MuiSvgIcon-root {
+      color: ${theme.palette.icon.tertiary};
+    }
+  `;
+
+  return (
+    <Box css={headerWrapperStyle}>
+      <Box css={headerInnerStyle}>
+        <Typography variant="h6" css={logoStyle}>
+          Dashboard
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<LogoutOutlinedIcon />}
+          onClick={handleLogout}
+          css={logoutButtonStyle}
+        >
+          로그아웃
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export default Header;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -85,11 +85,11 @@ const router = createBrowserRouter([
         element: <NotFound />,
       },
       {
-        path: '/admin/session' /* 추후 뺄 예정 */,
+        path: '/admin/session',
         element: <SessionDetail />,
       },
       {
-        path: '/admin/booth' /* 추후 뺄 예정 */,
+        path: '/admin/booth',
         element: <BoothDetail />,
       },
     ],
@@ -99,7 +99,6 @@ const router = createBrowserRouter([
     children: [
       {
         path: '/admin',
-        element: <div>AdminPage</div>,
       },
       {
         path: '*',

--- a/src/routes/layouts/Admin.tsx
+++ b/src/routes/layouts/Admin.tsx
@@ -20,8 +20,7 @@ const AdminLayout = () => {
           min-height: 100vh;
           max-width: 600px;
           margin: 0 auto;
-          padding: 100px 1rem 1rem; // 헤더 높이 + 여유
-          box-shadow: 0 0 20px #0000000d;
+          padding: 100px 1rem 1rem;
           background-color: ${palette.background.primary};
         `}
       >

--- a/src/routes/layouts/Admin.tsx
+++ b/src/routes/layouts/Admin.tsx
@@ -1,6 +1,6 @@
 import { Outlet, ScrollRestoration } from 'react-router-dom';
 import { css, useTheme, Box } from '@mui/material';
-import Header from '@components/AdminHeader';
+import Header from '@components/headers/AdminHeader';
 import UserCounts from '@components/AdminPage/UserCount';
 import SessionParticipation from '@components/AdminPage/SessionParticipation';
 import BoothParticipation from '@components/AdminPage/BoothParticipation';
@@ -11,38 +11,38 @@ import ConferenceRegistration from '@components/AdminPage/RegButtons';
 const AdminLayout = () => {
   const { palette } = useTheme();
   return (
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-        min-height: 100svh;
-        max-width: 600px;
-        margin: 0 auto;
-        padding: 1rem;
-        box-shadow: 0 0 20px #0000000d;
-        position: relative;
-        background-color: ${palette.background.primary};
-      `}
-    >
+    <>
       <Header />
-      <UserCounts />
-      <SessionParticipation />
-      <BoothParticipation />
-      <Box
+      <div
         css={css`
           display: flex;
-          justify-content: space-between; 
-          gap: 1rem; 
+          flex-direction: column;
+          min-height: 100vh;
+          max-width: 600px;
+          margin: 0 auto;
+          padding: 100px 1rem 1rem; // 헤더 높이 + 여유
+          box-shadow: 0 0 20px #0000000d;
+          background-color: ${palette.background.primary};
         `}
       >
-        <GradeRankingCard />
-        <PointRankingCard />
-      </Box>
-      <ConferenceRegistration />
-      <Outlet />
-      <ScrollRestoration />
-    </div>
+        <UserCounts />
+        <SessionParticipation />
+        <BoothParticipation />
+        <Box
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+          `}
+        >
+          <GradeRankingCard />
+          <PointRankingCard />
+        </Box>
+        <ConferenceRegistration />
+        <Outlet />
+        <ScrollRestoration />
+      </div>
+    </>
   );
 };
 

--- a/src/routes/pages/Booth.tsx
+++ b/src/routes/pages/Booth.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Typography, Box, Button } from '@mui/material';
-import Header from '@components/AdminHeader';
+import Header from '@components/headers/AdminHeader';
 import BoothBox from '@components/AdminPage/BoothBox';
 import { css, useTheme } from '@mui/material/styles';
 import { typography } from '@styles/foundation';

--- a/src/routes/pages/Session.tsx
+++ b/src/routes/pages/Session.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Typography, Box, Button } from '@mui/material';
-import Header from '@components/AdminHeader';
+import Header from '@components/headers/AdminHeader';
 import SessionBox from '@components/AdminPage/SessionBox';
 import { css, useTheme } from '@mui/material/styles';
 import { typography } from '@styles/foundation';


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/finalAdmin` → `dev`
<br/>

## ✅ 작업 내용

- 관리자 페이지 헤더 고정 구현
- 컨퍼런스 등록 전 + 아이콘 클릭 시 컨퍼런스 팝업 띄우기
- qr 팝업 구현
- 개인정보 팝업 단순 UI 구현
- 관리자페이지 헤더 폴더 이동

<br/>

## 🌠 이미지 첨부
1. 헤더 고정, 컨퍼런스 등록 전 + 아이콘 클릭

https://github.com/user-attachments/assets/1eb83025-17b2-4026-9dca-85d620380dea

2. 세션, 부스 QR 팝업

https://github.com/user-attachments/assets/bf3ccf9c-99ac-4084-9c1a-07a318a7bef5

3. 사용자 정보 팝업 
<img width="1508" alt="스크린샷 2025-03-20 오후 1 00 51" src="https://github.com/user-attachments/assets/bd83d29d-ce93-43e8-8667-bbc1c2c7a918" />


<br/>

## ✏️ 앞으로의 과제

- 채용담당자 UI 구현
<br/>

