### PR TITLE
feat: 관리자 페이지 대시보드, 상세 차트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fontsource/pretendard": "^5.2.5",
         "@mui/icons-material": "^6.4.7",
         "@mui/material": "^6.4.6",
+        "@mui/x-charts": "^7.28.0",
         "@tanstack/react-query": "^5.66.11",
         "@use-funnel/react-router-dom": "^0.0.11",
         "axios": "^1.8.1",
@@ -1433,6 +1434,144 @@
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
       "license": "MIT"
     },
+    "node_modules/@mui/x-charts": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-7.28.0.tgz",
+      "integrity": "sha512-TNfq/rQfGKnjTaEITkY6l09NpMxwMwRTgLiDw+JQsS/7gwBBJUmMhEOj67BaFeYTsroFLUYeggiAj+RTSryd4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/x-charts-vendor": "7.20.0",
+        "@mui/x-internals": "7.28.0",
+        "@react-spring/rafz": "^9.7.5",
+        "@react-spring/web": "^9.7.5",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts-vendor": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-7.20.0.tgz",
+      "integrity": "sha512-pzlh7z/7KKs5o0Kk0oPcB+sY0+Dg7Q7RzqQowDQjpy5Slz6qqGsgOB5YUzn0L+2yRmvASc4Pe0914Ao3tMBogg==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-delaunay": "^6.0.4",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "@types/d3-time": "^3.0.3",
+        "d3-color": "^3.1.0",
+        "d3-delaunay": "^6.0.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "delaunator": "^5.0.1",
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@react-spring/web": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@react-spring/web/node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-internals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.28.0.tgz",
+      "integrity": "sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1493,6 +1632,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.9",
@@ -1835,6 +1986,57 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2481,6 +2683,121 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -2504,6 +2821,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -3300,6 +3626,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4059,6 +4394,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.34.9",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource/pretendard": "^5.2.5",
     "@mui/icons-material": "^6.4.7",
     "@mui/material": "^6.4.6",
+    "@mui/x-charts": "^7.28.0",
     "@tanstack/react-query": "^5.66.11",
     "@use-funnel/react-router-dom": "^0.0.11",
     "axios": "^1.8.1",

--- a/src/components/AdminPage/DetailChart.tsx
+++ b/src/components/AdminPage/DetailChart.tsx
@@ -1,0 +1,162 @@
+import { BarChart } from '@mui/x-charts/BarChart';
+import { useTheme, css } from '@mui/material/styles';
+import { Box, Paper } from '@mui/material';
+import { useEffect } from 'react';
+
+const MAX_PARTICIPANT = 250;
+
+const DetailChart = () => {
+  const { palette, typo } = useTheme();
+
+  useEffect(() => {
+    const bars = document.querySelectorAll('.MuiBarElement-root');
+    bars.forEach((bar, index) => {
+      bar.setAttribute('data-index', String(index));
+    });
+  }, []);
+
+  return (
+    <Box
+      css={{
+        width: '100%',
+        overflowX: 'auto',
+      }}
+    >
+      <BarChart
+        dataset={dataset}
+        css={css`
+          color: ${palette.text.primary};
+          .MuiChartsAxis-directionY .MuiChartsAxis-tickLabel {
+            transform: translateX(-5px);
+          }
+          .MuiChartsAxis-directionX .MuiChartsAxis-tickLabel {
+            transform: translateY(5px);
+          }
+
+          .MuiBarElement-root {
+            fill: ${palette.graph.default} !important;
+          }
+
+          .MuiBarElement-root[data-index]:hover {
+            fill: ${palette.graph.hovered} !important;
+          }
+        `}
+        xAxis={[
+          {
+            scaleType: 'band',
+            dataKey: 'name',
+            valueFormatter,
+            tickPlacement: 'middle',
+            tickLabelStyle: {
+              ...typo.body.s,
+              color: palette.text.primary,
+            },
+          },
+        ]}
+        yAxis={[
+          {
+            tickNumber: 5,
+            tickLabelStyle: {
+              ...typo.body.s,
+              color: palette.text.primary,
+            },
+          },
+        ]}
+        series={[
+          {
+            dataKey: 'value',
+            highlightScope: {
+              highlight: 'none',
+            },
+          },
+        ]}
+        width={520}
+        height={200}
+        borderRadius={4}
+        tooltip={{ trigger: 'item' }}
+        slots={{
+          itemContent: (props) => (
+            <CustomItemTooltipContent {...props} dataset={dataset} />
+          ),
+        }}
+        margin={{ top: 30, left: 35, right: 10 }}
+      />
+    </Box>
+  );
+};
+
+export default DetailChart;
+
+const CustomItemTooltipContent = ({ ...props }) => {
+  const { palette, typo, radius } = useTheme();
+  console.log(props);
+  const { name, value } = props.dataset[props.itemData.dataIndex];
+
+  return (
+    <Paper
+      css={{
+        ...typo.body.s,
+        color: palette.text.secondary,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+        padding: '10px',
+        backgroundColor: palette.background.quaternary,
+        borderRadius: radius.md,
+        border: `1px solid ${palette.border.secondary}`,
+      }}
+    >
+      <p
+        css={{
+          display: 'flex',
+          justifyContent: 'center',
+          fontWeight: 'bold',
+          color: palette.text.primary,
+        }}
+      >
+        {name}
+      </p>
+      <p>참여: {value}명</p>
+      <p>비율: {Math.ceil((value / MAX_PARTICIPANT) * 100)}%</p>
+    </Paper>
+  );
+};
+
+const dataset = [
+  {
+    name: '데이터 분석',
+    value: 205,
+  },
+  {
+    name: 'AI',
+    value: 50,
+  },
+  {
+    name: '디자인',
+    value: 47,
+  },
+  {
+    name: '클라우드',
+    value: 54,
+  },
+  {
+    name: 'DevOps',
+    value: 57,
+  },
+  {
+    name: '소프트웨어 개발',
+    value: 57,
+  },
+  {
+    name: '기획/운영',
+    value: 59,
+  },
+  {
+    name: '기타',
+    value: 103,
+  },
+];
+
+export function valueFormatter(value: string | null) {
+  return `${value?.split(' ').join('\n')}`;
+}

--- a/src/components/AdminPage/PreviewChart.tsx
+++ b/src/components/AdminPage/PreviewChart.tsx
@@ -1,0 +1,123 @@
+import { Box, css, Paper, Typography, useTheme } from '@mui/material';
+
+const PreviewChart = () => {
+  const { palette, typo, radius } = useTheme();
+
+  const styles = {
+    date: css`
+      ${typo.title.xs};
+      color: ${palette.text.primary};
+    `,
+    now: css`
+      ${typo.body.l};
+      color: ${palette.text.tertiary};
+    `,
+    list: css`
+      margin-top: 34px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    `,
+  };
+
+  return (
+    <Paper
+      css={css`
+        text-align: center;
+        color: ${palette.text.secondary};
+        border-radius: ${radius.sm}px;
+        background-color: ${palette.background.secondary};
+        padding: 24px;
+        border: ${palette.divider_custom.primary};
+      `}
+    >
+      <div css={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+        <Typography variant="body1" css={styles.date}>
+          09/15
+        </Typography>
+        <Typography variant="body2" css={styles.now}>
+          18:20 18시 기준
+        </Typography>
+      </div>
+      <div css={styles.list}>
+        <ChartColumn
+          text="세션 1-1"
+          title="최신 기술 동향"
+          max={250}
+          current={200}
+        />
+        <ChartColumn
+          text="세션 1-2"
+          title="AI 기반 커뮤니케이션 도구의 발전"
+          max={250}
+          current={180}
+        />
+        <ChartColumn
+          text="세션 2-1"
+          title="디지털 시대의 리더십과 팀 빌딩"
+          max={250}
+          current={150}
+        />
+        <ChartColumn
+          text="세션 2-2"
+          title="원격 근무 환경에서의 생산성 향상 전략"
+          max={250}
+          current={120}
+        />
+      </div>
+    </Paper>
+  );
+};
+
+export default PreviewChart;
+
+interface ChartColumnProps {
+  max: number;
+  current: number;
+  text: string;
+  title: string;
+}
+const ChartColumn = (props: ChartColumnProps) => {
+  const { palette, typo } = useTheme();
+  const percentage = Math.ceil((props.current / props.max) * 100);
+
+  const styles = {
+    container: css`
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    `,
+    graph: css`
+      display: flex;
+      justify-content: end;
+      width: ${percentage}%;
+      background-color: ${palette.graph.default};
+      ${typo.sub.s}
+      color: ${palette.text.primary};
+      padding: 4px;
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+    `,
+    textlist: css`
+      display: flex;
+      gap: 10px;
+      color: ${palette.text.primary};
+    `,
+    bodyText: css`
+      ${typo.body.l}
+    `,
+    subText: css`
+      ${typo.sub.s}
+    `,
+  };
+  return (
+    <Box css={styles.container}>
+      <div css={styles.graph}>{percentage}%</div>
+      <div css={styles.textlist}>
+        <span css={styles.bodyText}>{props.text}</span>
+        <span css={styles.subText}>{props.title}</span>
+        <span css={styles.bodyText}>{`${props.current}/${props.max}`}</span>
+      </div>
+    </Box>
+  );
+};

--- a/src/components/AdminPage/PreviewChart.tsx
+++ b/src/components/AdminPage/PreviewChart.tsx
@@ -23,6 +23,7 @@ const PreviewChart = () => {
   return (
     <Paper
       css={css`
+        width: 100%;
         text-align: center;
         color: ${palette.text.secondary};
         border-radius: ${radius.sm}px;
@@ -31,40 +32,48 @@ const PreviewChart = () => {
         border: ${palette.divider_custom.primary};
       `}
     >
-      <div css={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
-        <Typography variant="body1" css={styles.date}>
-          09/15
-        </Typography>
-        <Typography variant="body2" css={styles.now}>
-          18:20 18시 기준
-        </Typography>
-      </div>
-      <div css={styles.list}>
-        <ChartColumn
-          text="세션 1-1"
-          title="최신 기술 동향"
-          max={250}
-          current={200}
-        />
-        <ChartColumn
-          text="세션 1-2"
-          title="AI 기반 커뮤니케이션 도구의 발전"
-          max={250}
-          current={180}
-        />
-        <ChartColumn
-          text="세션 2-1"
-          title="디지털 시대의 리더십과 팀 빌딩"
-          max={250}
-          current={150}
-        />
-        <ChartColumn
-          text="세션 2-2"
-          title="원격 근무 환경에서의 생산성 향상 전략"
-          max={250}
-          current={120}
-        />
-      </div>
+      <Box css={{ width: '100%', overflowX: 'auto' }}>
+        <div
+          css={{
+            minWidth: '520px',
+          }}
+        >
+          <div css={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+            <Typography variant="body1" css={styles.date}>
+              09/15
+            </Typography>
+            <Typography variant="body2" css={styles.now}>
+              18:20 18시 기준
+            </Typography>
+          </div>
+          <div css={styles.list}>
+            <ChartColumn
+              text="세션 1-1"
+              title="최신 기술 동향"
+              max={250}
+              current={200}
+            />
+            <ChartColumn
+              text="세션 1-2"
+              title="AI 기반 커뮤니케이션 도구의 발전"
+              max={250}
+              current={180}
+            />
+            <ChartColumn
+              text="세션 2-1"
+              title="디지털 시대의 리더십과 팀 빌딩"
+              max={250}
+              current={150}
+            />
+            <ChartColumn
+              text="세션 2-2"
+              title="원격 근무 환경에서의 생산성 향상 전략"
+              max={250}
+              current={120}
+            />
+          </div>
+        </div>
+      </Box>
     </Paper>
   );
 };

--- a/src/components/AdminPage/SessionBox.tsx
+++ b/src/components/AdminPage/SessionBox.tsx
@@ -6,6 +6,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ConfirmDeleteDialog from '../ConfirmDeleteDialog';
 import QRPopup from './Popup/QRPopup';
+import DetailChart from './DetailChart';
 
 interface SessionBoxProps {
   date: string;
@@ -18,7 +19,15 @@ interface SessionBoxProps {
   onEdit: () => void;
 }
 
-const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: SessionBoxProps) => {
+const SessionBox = ({
+  date,
+  place,
+  time,
+  title,
+  speaker,
+  onDelete,
+  onEdit,
+}: SessionBoxProps) => {
   const theme = useTheme();
   const { palette, spacing, typo } = theme;
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -29,10 +38,11 @@ const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: Ses
     display: flex;
     flex-direction: column;
     background-color: ${palette.background.quaternary};
-    padding: ${spacing(2)}px;
+    padding: 24px;
     border-radius: 18px;
     margin-bottom: ${spacing(2)}px;
     color: ${palette.text.primary};
+    overflow-x: auto;
   `;
 
   const infoStyle = css`
@@ -44,8 +54,8 @@ const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: Ses
   const iconContainerStyle = css`
     color: ${palette.icon.primary};
     position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 24px;
+    right: 24px;
     display: flex;
     gap: 2px;
   `;
@@ -71,24 +81,36 @@ const SessionBox = ({ date, place, time, title, speaker, onDelete, onEdit }: Ses
         />
 
         <Box css={iconContainerStyle}>
-          <IconButton size="small" color="inherit" onClick={() => setQrPopupOpen(true)}>
+          <IconButton
+            size="small"
+            color="inherit"
+            onClick={() => setQrPopupOpen(true)}
+          >
             <QrCodeIcon fontSize="small" />
           </IconButton>
           <IconButton size="small" color="inherit" onClick={onEdit}>
             <EditIcon fontSize="small" />
           </IconButton>
-          <IconButton size="small" color="inherit" onClick={() => setDeleteDialogOpen(true)}>
+          <IconButton
+            size="small"
+            color="inherit"
+            onClick={() => setDeleteDialogOpen(true)}
+          >
             <DeleteIcon fontSize="small" />
           </IconButton>
         </Box>
 
         {/* 정보 영역 */}
-        <Typography css={infoStyle}>{date} {place}</Typography>
+        <Typography css={infoStyle}>
+          {date} {place}
+        </Typography>
         <Typography css={infoStyle}>{time}</Typography>
-        <Typography css={infoStyle}>{title} {speaker}</Typography>
+        <Typography css={infoStyle}>
+          {title} {speaker}
+        </Typography>
 
         {/* 차트 데이터 영역 */}
-        <Typography variant="body2">!차트 데이터 표시 영역!</Typography>
+        <DetailChart />
       </Box>
     </>
   );

--- a/src/components/AdminPage/SessionParticipation.tsx
+++ b/src/components/AdminPage/SessionParticipation.tsx
@@ -4,142 +4,152 @@ import { css, useTheme } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import AddSession from './Popup/AddSession';
 import { useConferenceStore } from '@stores/client/useConferenceStore';
-import { useSessionStore } from '@stores/client/useSessionStore'; 
+import { useSessionStore } from '@stores/client/useSessionStore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { useNavigate } from 'react-router-dom';
 import ConferenceForm from './Popup/ConferenceForm';
+import PreviewChart from './PreviewChart';
 
 const SessionParticipation = () => {
-    const { palette, typography, radius } = useTheme();
-    const isConferenceRegistered = useConferenceStore((state) => state.isConferenceRegistered);
-    const { isSessionRegistered, hasAggregationData } = useSessionStore(); 
-    const [showAddSession, setShowAddSession] = useState(false);
-    const [showAddConference, setShowAddConference] = useState(false);
-    const navigate = useNavigate();
+  const { palette, typography, radius } = useTheme();
+  const isConferenceRegistered = useConferenceStore(
+    (state) => state.isConferenceRegistered,
+  );
+  const { isSessionRegistered, hasAggregationData } = useSessionStore();
+  const [showAddSession, setShowAddSession] = useState(false);
+  const [showAddConference, setShowAddConference] = useState(false);
+  const navigate = useNavigate();
 
-    const handleAddIconClick = () => {
-        if (isConferenceRegistered) {
-            setShowAddSession(true);
-        } else {
-            setShowAddConference(true);
-        }
-    };
+  const handleAddIconClick = () => {
+    if (isConferenceRegistered) {
+      setShowAddSession(true);
+    } else {
+      setShowAddConference(true);
+    }
+  };
 
-    const handleChevronClick = () => {
-        if (isConferenceRegistered) {
-            navigate('/admin/session');
-        } else {
-            alert('컨퍼런스를 등록해주세요');
-        }
-    };
-    const handleConferenceSubmit = (data: any) => {
-        console.log('컨퍼런스 등록 완료:', data);
-        setShowAddConference(false);
-    };
+  const handleChevronClick = () => {
+    if (isConferenceRegistered) {
+      navigate('/admin/session');
+    } else {
+      alert('컨퍼런스를 등록해주세요');
+    }
+  };
+  const handleConferenceSubmit = (data: any) => {
+    console.log('컨퍼런스 등록 완료:', data);
+    setShowAddConference(false);
+  };
 
-    return (
-        <Box position="relative">
-            <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
-                <Typography 
-                    variant="subtitle1" 
-                    fontWeight="bold"
-                    css={css`
-                        color: ${palette.text.primary};
-                        font-family: ${typography.fontFamily};
-                    `}
-                >
-                    세션 참여 현황
-                </Typography>
-                <ChevronRightIcon 
-                    css={css`
-                        color: ${palette.icon.primary};
-                        cursor: pointer;
-                    `}
-                    onClick={handleChevronClick}
-                />
-            </Box>
+  return (
+    <Box position="relative">
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={1}
+      >
+        <Typography
+          variant="subtitle1"
+          fontWeight="bold"
+          css={css`
+            color: ${palette.text.primary};
+            font-family: ${typography.fontFamily};
+          `}
+        >
+          세션 참여 현황
+        </Typography>
+        <ChevronRightIcon
+          css={css`
+            color: ${palette.icon.primary};
+            cursor: pointer;
+          `}
+          onClick={handleChevronClick}
+        />
+      </Box>
 
-            {!isConferenceRegistered ? (
-                <Paper
-                    css={css`
-                        text-align: center;
-                        color: ${palette.text.secondary};
-                        border-radius: ${radius.sm}px;
-                        background-color: ${palette.background.secondary};
-                        padding: 50px;
-                        border: ${palette.divider_custom.primary};
-                        cursor: pointer;
-                    `}
-                    onClick={handleAddIconClick}
-                >
-                    <AddIcon 
-                        css={css`
-                            font-size: 40px;
-                            color: ${palette.text.secondary};
-                            margin-bottom: 16px;
-                        `}
-                    />
-                    <Typography variant="body2">등록된 세션이 없습니다.</Typography>
-                    <Typography variant="body2">컨퍼런스 등록 후 확인 가능합니다.</Typography>
-                </Paper>
-            ) : !isSessionRegistered ? (
-                <Paper
-                    css={css`
-                        text-align: center;
-                        color: ${palette.text.secondary};
-                        border-radius: ${radius.sm}px;
-                        background-color: ${palette.background.secondary};
-                        padding: 50px;
-                        border: ${palette.divider_custom.primary};
-                        cursor: pointer;
-                    `}
-                    onClick={handleAddIconClick}
-                >
-                    <AddIcon 
-                        css={css`
-                            font-size: 40px;
-                            color: ${palette.text.secondary};
-                            margin-bottom: 16px;
-                        `}
-                    />
-                    <Typography variant="body2">등록된 세션이 없습니다.</Typography>
-                    <Typography variant="body2">세션 등록 후 확인 가능합니다.</Typography>
-                </Paper>
-            ) : !hasAggregationData ? (
-                <Paper
-                    css={css`
-                        text-align: center;
-                        color: ${palette.text.secondary};
-                        border-radius: ${radius.sm}px;
-                        background-color: ${palette.background.secondary};
-                        padding: 50px;
-                        border: ${palette.divider_custom.primary};
-                    `}
-                >
-                    <Typography variant="body2" mb={1}>
-                        집계된 정보가 없습니다.
-                    </Typography>
-                </Paper>
-            ) : (
-                <Typography>집계된 세션 정보 표시</Typography>
-            )}
+      {!isConferenceRegistered ? (
+        <Paper
+          css={css`
+            text-align: center;
+            color: ${palette.text.secondary};
+            border-radius: ${radius.sm}px;
+            background-color: ${palette.background.secondary};
+            padding: 50px;
+            border: ${palette.divider_custom.primary};
+            cursor: pointer;
+          `}
+          onClick={handleAddIconClick}
+        >
+          <AddIcon
+            css={css`
+              font-size: 40px;
+              color: ${palette.text.secondary};
+              margin-bottom: 16px;
+            `}
+          />
+          <Typography variant="body2">등록된 세션이 없습니다.</Typography>
+          <Typography variant="body2">
+            컨퍼런스 등록 후 확인 가능합니다.
+          </Typography>
+        </Paper>
+      ) : !isSessionRegistered ? (
+        <Paper
+          css={css`
+            text-align: center;
+            color: ${palette.text.secondary};
+            border-radius: ${radius.sm}px;
+            background-color: ${palette.background.secondary};
+            padding: 50px;
+            border: ${palette.divider_custom.primary};
+            cursor: pointer;
+          `}
+          onClick={handleAddIconClick}
+        >
+          <AddIcon
+            css={css`
+              font-size: 40px;
+              color: ${palette.text.secondary};
+              margin-bottom: 16px;
+            `}
+          />
+          <Typography variant="body2">등록된 세션이 없습니다.</Typography>
+          <Typography variant="body2">세션 등록 후 확인 가능합니다.</Typography>
+        </Paper>
+      ) : !hasAggregationData ? (
+        <Paper
+          css={css`
+            text-align: center;
+            color: ${palette.text.secondary};
+            border-radius: ${radius.sm}px;
+            background-color: ${palette.background.secondary};
+            padding: 50px;
+            border: ${palette.divider_custom.primary};
+          `}
+        >
+          <Typography variant="body2" mb={1}>
+            집계된 정보가 없습니다.
+          </Typography>
+        </Paper>
+      ) : (
+        <PreviewChart />
+      )}
 
-            {showAddSession && (
-                <AddSession 
-                    open={showAddSession}
-                    onClose={() => setShowAddSession(false)}
-                />
-            )}
-            {showAddConference && (
-                <ConferenceForm
-                    mode="add"
-                    open={showAddConference}
-                    onClose={() => setShowAddConference(false)}
-                    onSubmit={handleConferenceSubmit}
-                />
-            )}
-        </Box>
-    );
+      {showAddSession && (
+        <AddSession
+          open={showAddSession}
+          onClose={() => setShowAddSession(false)}
+        />
+      )}
+      {showAddConference && (
+        <ConferenceForm
+          mode="add"
+          open={showAddConference}
+          onClose={() => setShowAddConference(false)}
+          onSubmit={handleConferenceSubmit}
+        />
+      )}
+    </Box>
+  );
 };
 
 export default SessionParticipation;

--- a/src/components/SessionPage/QnaSection.tsx
+++ b/src/components/SessionPage/QnaSection.tsx
@@ -44,24 +44,28 @@ const QnaSection = () => {
       <Box
         component={'div'}
         css={css`
-          display: flex;
-          flex-direction: column;
-          gap: 20px;
-          padding: 16px;
-          height: 200px;
-          width: 100%;
+          border-radius: ${radius.xl};
           background-color: ${palette.opacity.opa100};
           border: 1px solid ${palette.border.primary};
-          border-radius: ${radius.xl};
-          overflow-y: auto;
-          &::-webkit-scrollbar {
-            display: none;
-          }
+          padding: 16px;
+          width: 100%;
+          height: 200px;
         `}
       >
-        {json.qna.map((item) => (
-          <Question key={item.id} {...item} />
-        ))}
+        <Box
+          css={css`
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            height: 100%;
+            overflow-y: auto;
+            padding-right: 10px;
+          `}
+        >
+          {json.qna.map((item) => (
+            <Question key={item.id} {...item} />
+          ))}
+        </Box>
       </Box>
       <Button
         css={css`

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -166,4 +166,31 @@ export const globalStyles = css`
     margin: 0;
     padding: 0;
   }
+
+  /* ✅ 스크롤바 스타일 추가 */
+  *::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: none; /* 스크롤바 트랙 색상 */
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background: #949494; /* 스크롤바 색상 */
+    border-radius: 10px; /* 둥근 모서리 */
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: #949494; /* 호버 시 색상 변경 */
+  }
+
+  textarea {
+    ::-webkit-scrollbar {
+      color: #949494;
+      background-color: #949494;
+      background: #949494;
+    }
+  }
 `;


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/admin-chart` → `dev`

<br/>

## ✅ 작업 내용

- 관리자 대시보드에서 확인 가능한 차트 프리뷰 구현
- 상세한 차트 구현 완료

<br/>

## 🌠 이미지 첨부

<img src="https://github.com/user-attachments/assets/7f14efe9-5e93-4746-9948-1dadf6a78b33" width="300"/>
<img src="https://github.com/user-attachments/assets/a981335b-a9c9-40fe-9fea-66995c1b9770" width="300"/>