### PR TITLE
feat(recruiter): 채용담당자 페이지 구현

### DIFF
--- a/src/components/RecruiterPage/CardContent.tsx
+++ b/src/components/RecruiterPage/CardContent.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import { css, Box, Typography, useTheme, IconButton } from '@mui/material';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import defaultProfileImg from 'src/assets/default-profile-img.png';
+
+const talentList = [
+    {
+        imageUrl: defaultProfileImg,
+        name: '최영호',
+        position: '프로덕트 디자이너',
+        skills: 'Figma, Sketch, ...',
+        experience: '5년 이상',
+    },
+    {
+        imageUrl: '/images/profile2.png',
+        name: '김지원',
+        position: '백엔드 개발자',
+        skills: 'Java, Spring Boot ...',
+        experience: '2년 이하',
+    },
+    {
+        imageUrl: '/images/profile3.png',
+        name: '정서연',
+        position: '프로덕트 디자이너',
+        skills: 'Figma, Framer ...',
+        experience: '2년 이하',
+    },
+    {
+        imageUrl: '/images/profile4.png',
+        name: '박시형',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '3~4년 이하',
+    },
+    {
+        imageUrl: '/images/profile5.png',
+        name: '이다영',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '3~4년 이하',
+    },
+    {
+        imageUrl: '/images/profile6.png',
+        name: '김다혜',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '5년 이상',
+    },
+];
+
+interface CardContentItemProps {
+    imageUrl: string;
+    name: string;
+    position: string;
+    skills: string;
+    experience: string;
+    onBookmarkClick?: () => void;
+    isBookmarked?: boolean;
+}
+
+const CardContentItem = ({
+    imageUrl,
+    name,
+    position,
+    skills,
+    experience,
+}: CardContentItemProps) => {
+    const { palette } = useTheme();
+    const [isBookmarked, setIsBookmarked] = useState(false);
+
+    const handleBookmarkClick = () => {
+        setIsBookmarked(!isBookmarked);
+    };
+    
+    return (
+        <Box
+        css={css`
+            background-color: ${palette.background.tertiary};
+            border-radius: 18px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            flex: 1 0 0;
+            min-width: 166px;
+            max-width: 280px;
+        `}
+        >
+        <Box
+            css={css`
+                width: 70px;
+                height: 98px;
+                overflow: hidden;
+                margin-bottom: 12px;
+            `}
+        >
+            <img
+            src={imageUrl}
+            alt={`${name} 프로필 이미지`}
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+        </Box>
+
+        <Typography
+            css={css`
+                font-size: 16px;
+                font-weight: 700;
+                color: ${palette.text.primary};
+                margin-bottom: 4px;
+            `}
+        >
+            {name}
+        </Typography>
+        <Typography
+            css={css`
+                font-size: 14px;
+                font-weight: 500;
+                color: ${palette.text.primary};
+                margin-bottom: 4px;
+            `}
+        >
+            {position}
+        </Typography>
+        <Typography
+            css={css`
+                font-size: 12px;
+                color: ${palette.text.primary};
+                margin-bottom: 12px;
+                line-height: 1.4;
+            `}
+        >
+            {skills}
+        </Typography>
+
+        <Box
+            css={css`
+                width: 100%;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            `}
+        >
+            <Typography
+            css={css`
+                font-size: 12px;
+                color: ${palette.text.secondary};
+            `}
+            >
+            {experience}
+            </Typography>
+            <IconButton onClick={handleBookmarkClick}>
+            {isBookmarked ? (
+                <FavoriteIcon sx={{ color: '#EB5050', fontSize: 20 }} />
+            ) : (
+                <FavoriteBorderIcon sx={{ color: palette.text.secondary, fontSize: 20 }} />
+            )}
+            </IconButton>
+        </Box>
+        </Box>
+    );
+};
+
+const CardContent = () => {
+    return (
+        <Box
+            css={css`
+                display: flex;
+                flex-wrap: wrap;
+                gap: 16px;
+                justify-content: space-between;
+            `}
+        >
+        {talentList.map((talent, index) => (
+            <CardContentItem key={index} {...talent} />
+        ))}
+        </Box>
+    );
+};
+
+export default CardContent;

--- a/src/components/RecruiterPage/FilterModal.tsx
+++ b/src/components/RecruiterPage/FilterModal.tsx
@@ -1,0 +1,150 @@
+import { css, Box, Button, Typography, useTheme } from '@mui/material';
+import AnimatedModal from '@components/AnimatedModal';
+import { useState, useEffect } from 'react';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+interface FilterModalProps {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    items: string[];
+    selectedItems: string[];
+    onChange: (selected: string[]) => void;
+    multiSelect?: boolean;
+    hasSelectAll?: boolean;
+}
+
+const FilterModal = ({
+    open,
+    onClose,
+    title,
+    items,
+    selectedItems,
+    onChange,
+    multiSelect = false,
+    hasSelectAll = false,
+}: FilterModalProps) => {
+    const { palette, radius, typo } = useTheme();
+    const [tempSelected, setTempSelected] = useState<string[]>([]);
+
+    useEffect(() => {
+        if (open) {
+        setTempSelected(selectedItems);
+        }
+    }, [open, selectedItems]);
+
+    const isAllSelected = tempSelected.length === items.length;
+    
+    const handleItemClick = (item: string) => {
+        if (hasSelectAll && item === '모두 보기') {
+            if (isAllSelected) {
+                setTempSelected([]);
+            } else {
+                setTempSelected([...items]);
+            }
+        return;
+        }
+        if (multiSelect) {
+            setTempSelected((prev) =>
+                prev.includes(item)
+            ? prev.filter((i) => i !== item)
+            : [...prev, item]
+        );
+        } else {
+            setTempSelected([item]);
+        }
+    };
+
+    const handleConfirm = () => {
+        onChange(tempSelected);
+        onClose();
+    };
+    
+    const displayItems = hasSelectAll ? ['모두 보기', ...items] : items;
+    
+    return (
+        <AnimatedModal open={open} onClose={onClose}>
+        <Typography
+            css={css`
+                font-size: 16px;
+                font-weight: bold;
+                margin-bottom: 16px;
+                font-family: ${typo.fontFamily.Pretendard};
+                color: ${palette.text.primary};
+            `}
+        >
+            {title}
+        </Typography>
+
+        <Box
+            css={css`
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            `}
+        >
+            {displayItems.map((item) => {
+            const isSelected =
+                item === '모두 보기' ? isAllSelected : tempSelected.includes(item);
+
+            return (
+                <Box
+                key={item}
+                onClick={() => handleItemClick(item)}
+                css={css`
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    background-color: ${palette.background.tertiary};
+                    border-radius: ${radius.md};
+                    padding: 10px 16px;
+                    cursor: pointer;
+                `}
+                >
+                <Typography
+                    css={css`
+                        font-family: ${typo.fontFamily.Pretendard};
+                        color: ${palette.text.primary};
+                        font-size: 14px;
+                    `}
+                >
+                    {item}
+                </Typography>
+                {isSelected ? (
+                    <CheckCircleIcon
+                    css={css`
+                        color: ${palette.icon.primary};
+                    `}
+                    />
+                ) : (
+                    <CheckCircleOutlineIcon
+                    css={css`
+                        color: ${palette.icon.primary};
+                    `}
+                    />
+                )}
+                </Box>
+            );
+            })}
+        </Box>
+
+        <Button
+            variant="contained"
+            fullWidth
+            onClick={handleConfirm}
+            css={css`
+                background-color: ${palette.background.quinary};
+                margin-top: 24px;
+                border-radius: 12px;
+                border: none;
+                padding: 10px 0;
+            `}
+        >
+            완료
+        </Button>
+        </AnimatedModal>
+    );
+};
+
+export default FilterModal;

--- a/src/components/RecuiterPage/CardContent.tsx
+++ b/src/components/RecuiterPage/CardContent.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react';
+import { css, Box, Typography, useTheme, IconButton } from '@mui/material';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import defaultProfileImg from 'src/assets/default-profile-img.png';
+
+const talentList = [
+    {
+        imageUrl: defaultProfileImg,
+        name: '최영호',
+        position: '프로덕트 디자이너',
+        skills: 'Figma, Sketch, ...',
+        experience: '5년 이상',
+    },
+    {
+        imageUrl: '/images/profile2.png',
+        name: '김지원',
+        position: '백엔드 개발자',
+        skills: 'Java, Spring Boot ...',
+        experience: '2년 이하',
+    },
+    {
+        imageUrl: '/images/profile3.png',
+        name: '정서연',
+        position: '프로덕트 디자이너',
+        skills: 'Figma, Framer ...',
+        experience: '2년 이하',
+    },
+    {
+        imageUrl: '/images/profile4.png',
+        name: '박시형',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '3~4년 이하',
+    },
+    {
+        imageUrl: '/images/profile5.png',
+        name: '이다영',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '3~4년 이하',
+    },
+    {
+        imageUrl: '/images/profile6.png',
+        name: '김다혜',
+        position: '프론트엔드 개발자',
+        skills: 'JavaScript, TypeS ...',
+        experience: '5년 이상',
+    },
+];
+
+interface CardContentItemProps {
+    imageUrl: string;
+    name: string;
+    position: string;
+    skills: string;
+    experience: string;
+    onBookmarkClick?: () => void;
+    isBookmarked?: boolean;
+}
+
+const CardContentItem = ({
+    imageUrl,
+    name,
+    position,
+    skills,
+    experience,
+}: CardContentItemProps) => {
+    const { palette } = useTheme();
+    const [isBookmarked, setIsBookmarked] = useState(false);
+
+    const handleBookmarkClick = () => {
+        setIsBookmarked(!isBookmarked);
+    };
+    
+    return (
+        <Box
+        css={css`
+            background-color: ${palette.background.tertiary};
+            border-radius: 18px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            flex: 1 0 0;
+            min-width: 166px;
+            max-width: 280px;
+        `}
+        >
+        <Box
+            css={css`
+                width: 70px;
+                height: 98px;
+                overflow: hidden;
+                margin-bottom: 12px;
+            `}
+        >
+            <img
+            src={imageUrl}
+            alt={`${name} 프로필 이미지`}
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+        </Box>
+
+        <Typography
+            css={css`
+                font-size: 16px;
+                font-weight: 700;
+                color: ${palette.text.primary};
+                margin-bottom: 4px;
+            `}
+        >
+            {name}
+        </Typography>
+        <Typography
+            css={css`
+                font-size: 14px;
+                font-weight: 500;
+                color: ${palette.text.primary};
+                margin-bottom: 4px;
+            `}
+        >
+            {position}
+        </Typography>
+        <Typography
+            css={css`
+                font-size: 12px;
+                color: ${palette.text.primary};
+                margin-bottom: 12px;
+                line-height: 1.4;
+            `}
+        >
+            {skills}
+        </Typography>
+
+        <Box
+            css={css`
+                width: 100%;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            `}
+        >
+            <Typography
+            css={css`
+                font-size: 12px;
+                color: ${palette.text.secondary};
+            `}
+            >
+            {experience}
+            </Typography>
+            <IconButton onClick={handleBookmarkClick}>
+            {isBookmarked ? (
+                <FavoriteIcon sx={{ color: '#EB5050', fontSize: 20 }} />
+            ) : (
+                <FavoriteBorderIcon sx={{ color: palette.text.secondary, fontSize: 20 }} />
+            )}
+            </IconButton>
+        </Box>
+        </Box>
+    );
+};
+
+const CardContent = () => {
+    return (
+        <Box
+            css={css`
+                display: flex;
+                flex-wrap: wrap;
+                gap: 16px;
+                justify-content: space-between;
+            `}
+        >
+        {talentList.map((talent, index) => (
+            <CardContentItem key={index} {...talent} />
+        ))}
+        </Box>
+    );
+};
+
+export default CardContent;

--- a/src/components/RecuiterPage/FilterModal.tsx
+++ b/src/components/RecuiterPage/FilterModal.tsx
@@ -1,0 +1,150 @@
+import { css, Box, Button, Typography, useTheme } from '@mui/material';
+import AnimatedModal from '@components/AnimatedModal';
+import { useState, useEffect } from 'react';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+interface FilterModalProps {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    items: string[];
+    selectedItems: string[];
+    onChange: (selected: string[]) => void;
+    multiSelect?: boolean;
+    hasSelectAll?: boolean;
+}
+
+const FilterModal = ({
+    open,
+    onClose,
+    title,
+    items,
+    selectedItems,
+    onChange,
+    multiSelect = false,
+    hasSelectAll = false,
+}: FilterModalProps) => {
+    const { palette, radius, typo } = useTheme();
+    const [tempSelected, setTempSelected] = useState<string[]>([]);
+
+    useEffect(() => {
+        if (open) {
+        setTempSelected(selectedItems);
+        }
+    }, [open, selectedItems]);
+
+    const isAllSelected = tempSelected.length === items.length;
+    
+    const handleItemClick = (item: string) => {
+        if (hasSelectAll && item === '모두 보기') {
+            if (isAllSelected) {
+                setTempSelected([]);
+            } else {
+                setTempSelected([...items]);
+            }
+        return;
+        }
+        if (multiSelect) {
+            setTempSelected((prev) =>
+                prev.includes(item)
+            ? prev.filter((i) => i !== item)
+            : [...prev, item]
+        );
+        } else {
+            setTempSelected([item]);
+        }
+    };
+
+    const handleConfirm = () => {
+        onChange(tempSelected);
+        onClose();
+    };
+    
+    const displayItems = hasSelectAll ? ['모두 보기', ...items] : items;
+    
+    return (
+        <AnimatedModal open={open} onClose={onClose}>
+        <Typography
+            css={css`
+                font-size: 16px;
+                font-weight: bold;
+                margin-bottom: 16px;
+                font-family: ${typo.fontFamily.Pretendard};
+                color: ${palette.text.primary};
+            `}
+        >
+            {title}
+        </Typography>
+
+        <Box
+            css={css`
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            `}
+        >
+            {displayItems.map((item) => {
+            const isSelected =
+                item === '모두 보기' ? isAllSelected : tempSelected.includes(item);
+
+            return (
+                <Box
+                key={item}
+                onClick={() => handleItemClick(item)}
+                css={css`
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    background-color: ${palette.background.tertiary};
+                    border-radius: ${radius.md};
+                    padding: 10px 16px;
+                    cursor: pointer;
+                `}
+                >
+                <Typography
+                    css={css`
+                        font-family: ${typo.fontFamily.Pretendard};
+                        color: ${palette.text.primary};
+                        font-size: 14px;
+                    `}
+                >
+                    {item}
+                </Typography>
+                {isSelected ? (
+                    <CheckCircleIcon
+                    css={css`
+                        color: ${palette.icon.primary};
+                    `}
+                    />
+                ) : (
+                    <CheckCircleOutlineIcon
+                    css={css`
+                        color: ${palette.icon.primary};
+                    `}
+                    />
+                )}
+                </Box>
+            );
+            })}
+        </Box>
+
+        <Button
+            variant="contained"
+            fullWidth
+            onClick={handleConfirm}
+            css={css`
+                background-color: ${palette.background.quinary};
+                margin-top: 24px;
+                border-radius: 12px;
+                border: none;
+                padding: 10px 0;
+            `}
+        >
+            완료
+        </Button>
+        </AnimatedModal>
+    );
+};
+
+export default FilterModal;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,6 +19,10 @@ import BoothPage from './pages/BoothPage';
 import BoothDetails from './pages/BoothDetails';
 import SessionPage from './pages/SessionPage';
 import MyInfo from './pages/MyInfo';
+import RecruiterNavLayout from './layouts/RecruiterNav';
+import RecruiterPage from './pages/RecruiterPage';
+import RecruiterMyPage from './pages/RecruiterMypage';
+import RecruiterMain from './pages/RecruiterMain';
 
 const router = createBrowserRouter([
   {
@@ -111,6 +115,24 @@ const router = createBrowserRouter([
       },
     ],
   },
+  {
+    path: '/recruiter',
+    element: <RecruiterNavLayout />,
+    children: [
+      {
+        path: 'list',
+        element: <RecruiterPage />,
+      },
+      {
+        path: 'mypage',
+        element: <RecruiterMyPage />,
+      },
+      {
+        path: 'main',
+        element: <RecruiterMain />,
+      }
+    ],
+  }
 ]);
 
 export default function Router() {

--- a/src/routes/layouts/RecruiterNav.tsx
+++ b/src/routes/layouts/RecruiterNav.tsx
@@ -1,0 +1,87 @@
+import { NavLink, Outlet, ScrollRestoration, useLocation } from 'react-router-dom';
+import { Button, styled } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import DefaultHeader from '@components/headers/DefaultHeader';
+
+const RecruiterNavLayout = () => {
+  const { palette } = useTheme();
+  const location = useLocation();
+
+  const hideHeader = location.pathname.includes('/recruiter/mypage') || location.pathname.includes('/recruiter/main');
+
+  return (
+    <div
+      css={css`
+        position: fixed;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        flex-direction: column;
+        max-width: 600px;
+        min-width: 375px;
+        height: 100%;
+        width: 100%;
+        margin: 0 auto;
+        box-shadow: 0 0 20px #0000000d;
+        background-color: ${palette.background.primary};
+      `}
+    >
+      {!hideHeader && <DefaultHeader backgroundColor={palette.background.primary} />}
+      <div
+        css={css`
+          flex: 1;
+          overflow-y: auto;
+        `}
+      >
+        <Outlet />
+      </div>
+      <ScrollRestoration />
+      <RecuiterNavigation />
+    </div>
+  );
+};
+
+export default RecruiterNavLayout;
+
+const RecuiterNavigation = () => {
+  return (
+    <Nav>
+      <CustomLink to="/recruiter/list">
+        <CustomButton>LIST</CustomButton>
+      </CustomLink>
+      <CustomLink to="/recruiter/mypage">
+        <CustomButton>MY</CustomButton>
+      </CustomLink>
+    </Nav>
+  );
+};
+
+const Nav = styled('nav')`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 600px;
+`;
+
+const CustomLink = styled(NavLink)(
+  ({ theme }) => css`
+    width: 50%;
+    background-color: ${theme.palette.background.primary};
+  `,
+);
+
+const CustomButton = styled(Button)(
+  ({ theme }) => css`
+    width: 100%;
+    padding: 16px 10px;
+    border: 1px solid ${theme.palette.border.primary};
+    border-radius: 0;
+    font-weight: 800;
+    color: ${theme.palette.text.primary};
+    background-color: ${theme.palette.background.primary};
+
+    .active & {
+      background-color: ${theme.palette.background.secondary};
+    }
+  `,
+);

--- a/src/routes/layouts/RecuiterNav.tsx
+++ b/src/routes/layouts/RecuiterNav.tsx
@@ -1,0 +1,79 @@
+import { NavLink, Outlet, ScrollRestoration } from 'react-router-dom';
+import { Button, styled } from '@mui/material';
+import { css, useTheme } from '@mui/material';
+import DefaultHeader from '@components/headers/DefaultHeader';
+
+const RecuiterNavLayout = () => {
+  const { palette } = useTheme();
+  
+  return (
+    <div
+      css={css`
+        position: fixed;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        flex-direction: column;
+        max-width: 600px;
+        min-width: 375px;
+        height: 100%;
+        width: 100%;
+        margin: 0 auto;
+        box-shadow: 0 0 20px #0000000d;
+        background-color: ${palette.background.primary};
+      `}
+    >
+      <DefaultHeader backgroundColor={palette.background.primary} />
+      <Outlet />
+      <ScrollRestoration />
+      <RecuiterNavigation />
+    </div>
+  );
+};
+
+export default RecuiterNavLayout;
+
+const RecuiterNavigation = () => {
+  return (
+    <Nav>
+      <CustomLink to="/recuiter/list">
+        <CustomButton>LIST</CustomButton>
+      </CustomLink>
+      <CustomLink to="/recuiter/mypage">
+        <CustomButton>MY</CustomButton>
+      </CustomLink>
+    </Nav>
+  );
+};
+
+const Nav = styled('nav')`
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  max-width: 600px;
+`;
+
+const CustomLink = styled(NavLink)(
+  ({ theme }) => css`
+    width: 50%;
+    background-color: ${theme.palette.background.primary};
+  `,
+);
+
+const CustomButton = styled(Button)(
+  ({ theme }) => css`
+    width: 100%;
+    padding: 16px 10px;
+    border: 1px solid ${theme.palette.border.primary};
+    border-radius: 0;
+    font-weight: 800;
+    color: ${theme.palette.text.primary};
+    background-color: ${theme.palette.background.primary};
+
+    .active & {
+      background-color: ${theme.palette.background.secondary};
+    }
+  `,
+);

--- a/src/routes/pages/RecruiterMain.tsx
+++ b/src/routes/pages/RecruiterMain.tsx
@@ -1,0 +1,43 @@
+import { useTheme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import BackHeader from '@components/headers/BackHeader';
+import { Box, Typography, css } from '@mui/material';
+
+const RecruiterMain = () => {
+  const { palette, typo } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <BackHeader
+        backgroundColor={palette.background.primary}
+        onClick={() => navigate(-1)}
+      />
+      <Box
+        css={css`
+          max-width: 600px;
+          margin: 0 auto;
+          padding: 20px 16px 0;
+          background-color: ${palette.background.primary};
+          height: 100%;
+          overflow-y: auto;
+        `}
+      >
+        <Typography
+          css={css`
+            font-family: ${typo.fontFamily.Pretendard};
+            font-size: 26px;
+            font-style: normal;
+            font-weight: 700;
+            line-height: normal;
+            color: ${palette.text.primary};
+          `}
+        >
+          내가 저장한 인재
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export default RecruiterMain;

--- a/src/routes/pages/RecruiterMypage.tsx
+++ b/src/routes/pages/RecruiterMypage.tsx
@@ -3,6 +3,7 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import defaultProfileImg from 'src/assets/default-profile-img.png';
 import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
 import { useNavigate } from 'react-router-dom';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 
 const talentList = [
   {
@@ -270,16 +271,14 @@ const RecruiterMypage = () => {
           >
             내가 저장한 인재 ({talentList.length})
           </Typography>
-          <Typography
+          <ArrowForwardIosIcon
             css={css`
-              font-size: 20px;
+              font-size: 16px;
               cursor: pointer;
               color: ${palette.icon.primary};
             `}
             onClick={() => navigate('/recruiter/main')}
-          >
-            &gt;
-          </Typography>
+          />
         </Box>
 
         {talentList.length === 0 ? (

--- a/src/routes/pages/RecruiterMypage.tsx
+++ b/src/routes/pages/RecruiterMypage.tsx
@@ -1,0 +1,315 @@
+import { Box, Typography, useTheme, css } from '@mui/material';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import defaultProfileImg from 'src/assets/default-profile-img.png';
+import LogoutOutlinedIcon from '@mui/icons-material/LogoutOutlined';
+import { useNavigate } from 'react-router-dom';
+
+const talentList = [
+  {
+    imageUrl: defaultProfileImg,
+    name: '김지원',
+    position: '백엔드 개발자',
+    skills: 'Java, Spring Boot ...',
+    experience: '2년 이하',
+  },
+  {
+    imageUrl: defaultProfileImg,
+    name: '최영호',
+    position: '프로덕트 디자이너',
+    skills: 'Figma, Sketch ...',
+    experience: '5년 이상',
+  },
+  {
+    imageUrl: defaultProfileImg,
+    name: '정서연',
+    position: '프로덕트 디자이너',
+    skills: 'Figma, Framer ...',
+    experience: '2년 이하',
+  },
+  {
+    imageUrl: defaultProfileImg,
+    name: '박시형',
+    position: '프론트엔드 개발자',
+    skills: 'JavaScript, TypeS ...',
+    experience: '3~4년 이하',
+  },
+  {
+    imageUrl: defaultProfileImg,
+    name: '이유진',
+    position: '데이터 엔지니어',
+    skills: 'Python, SQL, Airf ...',
+    experience: '3년 이상',
+  },
+  {
+    imageUrl: defaultProfileImg,
+    name: '한지민',
+    position: 'UX 리서처',
+    skills: 'User Research, Pers ...',
+    experience: '4년 이상',
+  },
+];
+
+interface CardContentItemProps {
+  imageUrl: string;
+  name: string;
+  position: string;
+  skills: string;
+  experience: string;
+}
+
+const CardContentItem = ({
+  imageUrl,
+  name,
+  position,
+  skills,
+  experience,
+}: CardContentItemProps) => {
+  const { palette } = useTheme();
+  
+  return (
+    <Box
+      css={css`
+        background-color: ${palette.background.tertiary};
+        border-radius: 18px;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        flex: 1 0 0;
+        min-width: 166px;
+        max-width: 280px;
+      `}
+    >
+      <Box
+        css={css`
+          width: 70px;
+          height: 98px;
+          overflow: hidden;
+          margin-bottom: 12px;
+        `}
+      >
+        <img
+          src={imageUrl}
+          alt={`${name} 프로필 이미지`}
+          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+        />
+      </Box>
+
+      <Typography
+        css={css`
+          font-size: 16px;
+          font-weight: 700;
+          color: ${palette.text.primary};
+          margin-bottom: 4px;
+        `}
+      >
+        {name}
+      </Typography>
+      <Typography
+        css={css`
+          font-size: 14px;
+          font-weight: 500;
+          color: ${palette.text.primary};
+          margin-bottom: 4px;
+        `}
+      >
+        {position}
+      </Typography>
+      <Typography
+        css={css`
+          font-size: 12px;
+          color: ${palette.text.primary};
+          margin-bottom: 12px;
+          line-height: 1.4;
+        `}
+      >
+        {skills}
+      </Typography>
+
+      <Box
+        css={css`
+          width: 100%;
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        `}
+      >
+        <Typography
+          css={css`
+            font-size: 12px;
+            color: ${palette.text.secondary};
+          `}
+        >
+          {experience}
+        </Typography>
+        <FavoriteIcon sx={{ color: '#EB5050', fontSize: 20 }} />
+      </Box>
+    </Box>
+  );
+};
+
+const RecruiterMypage = () => {
+  const { palette, typo } = useTheme();
+  const navigate = useNavigate();
+  return (
+    <Box
+      css={css`
+        height: 100%;
+        overflow-y: auto;
+        border-radius: 0px 0px var(--radius-18, 18px) var(--radius-18, 18px);
+        background-color: var(--opacity-opa100, rgba(67, 67, 67, 0.50));
+        backdrop-filter: blur(5px);
+      `}
+    >
+      <Box
+        css={css`
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 20px;
+          background-color: ${palette.background.tertiary};
+          padding: 24px;
+          height: 357px;
+          border-bottom-left-radius: 18px;
+          border-bottom-right-radius: 18px;
+        `}
+      >
+        <Typography
+          css={css`
+            font-size: 20px;
+            text-align: center;
+            font-weight: 800;
+            font-family: ${typo.fontFamily.Montserrat};
+            color: ${palette.text.primary};
+          `}
+        >
+          F'LINK 2025
+        </Typography>
+        <img
+          src="/images/company-logo.png"
+          alt="company logo"
+          css={css`
+            width: 100px;
+            height: 100px;
+            border-radius: 50%;
+          `}
+        />
+        <Box textAlign="center">
+          <Typography
+            css={css`
+              color: ${palette.text.primary};
+              font-size: 24px;
+              font-weight: 700;
+              margin-bottom: 4px;
+            `}
+          >
+            박수진 님, 반갑습니다.
+          </Typography>
+          <Typography
+            css={css`
+              font-size: 14px;
+              color: ${palette.text.secondary};
+            `}
+          >
+            CodeSphere HR팀 매니저
+          </Typography>
+        </Box>
+        <Box
+          css={css`
+            margin-top: 12px;
+            padding: 6px 16px;
+            background-color: ${palette.background.quaternary};
+            border-radius: 20px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+          `}
+          onClick={() => navigate('/role-selection')}
+        >
+          <LogoutOutlinedIcon 
+            css={css`
+              width: 16px;
+              height: 16px;
+              color: ${palette.icon.tertiary}
+              `}
+            />
+          <Typography
+            css={css`
+              font-size: 14px;
+              font-weight: 500;
+              color: ${palette.text.primary};
+            `}
+          >
+            로그아웃
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box
+        css={css`
+          background-color: ${palette.background.primary};
+          padding: 20px;
+          flex: 1;
+        `}
+      >
+        <Box
+          css={css`
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 16px;
+          `}
+        >
+          <Typography
+            css={css`
+              font-size: 16px;
+              font-weight: 700;
+              color: ${palette.text.primary};
+            `}
+          >
+            내가 저장한 인재 ({talentList.length})
+          </Typography>
+          <Typography
+            css={css`
+              font-size: 20px;
+              cursor: pointer;
+              color: ${palette.icon.primary};
+            `}
+            onClick={() => navigate('/recruiter/main')}
+          >
+            &gt;
+          </Typography>
+        </Box>
+
+        {talentList.length === 0 ? (
+          <Typography
+            css={css`
+              color: ${palette.text.secondary};
+              text-align: center;
+              margin-top: 40px;
+              font-size: 14px;
+            `}
+          >
+            집계된 정보가 없습니다.
+          </Typography>
+        ) : (
+          <Box
+            css={css`
+              display: flex;
+              flex-wrap: wrap;
+              gap: 16px;
+              justify-content: flex-start;
+            `}
+          >
+            {talentList.map((talent, index) => (
+              <CardContentItem key={index} {...talent} />
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default RecruiterMypage;

--- a/src/routes/pages/RecruiterPage.tsx
+++ b/src/routes/pages/RecruiterPage.tsx
@@ -1,0 +1,184 @@
+import { css, Box, Button, Typography, useTheme } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useState } from 'react';
+import FilterMultiSelectModal from '@components/RecruiterPage/FilterModal';
+import CardContent from '@components/RecruiterPage/CardContent';
+
+const jobOptions = [
+  '프론트엔드 개발자', '백엔드 개발자', '풀스택 개발자', 'AI/머신러닝 엔지니어',
+  '클라우드 엔지니어', 'DevOps 엔지니어', '데이터 엔지니어', '모바일 앱 개발자',
+  '임베디드 시스템 개발자', '블록체인 개발자', '프로덕트 디자이너', '그래픽 디자이너',
+  '웹디자이너', '프로젝트 매니저', '데이터 분석가', '마케터', '학생', '취업 준비생', '연구원'
+];
+
+const educationOptions = ['고등학교 졸업', '2~3년제 졸업', '4년제 졸업', '대학원 석/박사'];
+
+const ageOptions = ['20~24세 이하', '25~29세 이하', '30~34세 이하', '35세 이상'];
+
+const experienceOptions = ['신입', '1~2년 이하', '3~4년 이하', '5년 이상'];
+
+const regionOptions = [
+  '수도권', '부산광역시', '대구광역시', '대전광역시', '광주광역시', '울산광역시',
+  '세종특별자치시', '강원권', '충청권', '전라권', '경상권', '제주특별자치도'
+];
+
+const RecruiterPage = () => {
+  const { palette, typo } = useTheme();
+
+  const [jobFilter, setJobFilter] = useState<string[]>([]);
+  const [educationFilter, setEducationFilter] = useState<string[]>([]);
+  const [ageFilter, setAgeFilter] = useState<string[]>([]);
+  const [experienceFilter, setExperienceFilter] = useState<string[]>([]);
+  const [regionFilter, setRegionFilter] = useState<string[]>([]);
+
+  const [modalType, setModalType] = useState<string | null>(null);
+
+  const openModal = (type: string) => setModalType(type);
+  const closeModal = () => setModalType(null);
+  
+  return (
+    <Box
+      css={css`
+        width: 100%;
+        max-width: 600px;
+        height: 100%;
+        background-color: ${palette.background.primary};
+        display: flex;
+        flex-direction: column;
+        margin: 0 auto;
+      `}
+    >
+      <Box
+        css={css`
+          padding: 24px 16px 0;
+          flex-shrink: 0;
+        `}
+      >
+        <Typography
+          css={css`
+            font-size: 26px;
+            font-weight: bold;
+            margin-bottom: 8px;
+            font-family: ${typo.fontFamily.Pretendard};
+            color: ${palette.text.primary};
+          `}
+        >
+          인재 둘러보기
+        </Typography>
+        <Typography
+          css={css`
+            font-size: 16px;
+            color: ${palette.text.secondary};
+            ${typo.body.l};
+          `}
+        >
+          우리 회사에 적합한 인재를 저장해보세요.
+        </Typography>
+
+        <Box
+          css={css`
+            display: flex;
+            overflow-x: auto;
+            gap: 8px;
+            margin-bottom: 24px;
+            margin-top: 10px;
+            padding-bottom: 8px;
+            &::-webkit-scrollbar {
+              display: none;
+            }
+          `}
+        >
+          {[
+            { label: '직무', type: 'job' },
+            { label: '학력', type: 'education' },
+            { label: '연령대', type: 'age' },
+            { label: '경력', type: 'experience' },
+            { label: '희망 근무지', type: 'region' },
+          ].map(({ label, type }) => (
+            <Button
+              key={type}
+              onClick={() => openModal(type)}
+              variant="contained"
+              endIcon={
+                <ExpandMoreIcon
+                  sx={{ fontSize: 18, color: palette.text.primary }}
+                />
+              }
+              css={css`
+                flex-shrink: 0;
+                background-color: ${palette.background.secondary};
+                color: ${palette.text.secondary};
+                border-radius: 18px;
+                border: none;
+                padding: 6px 12px;
+                font-weight: 600;
+                font-size: 14px;
+                text-transform: none;
+              `}
+            >
+              {label}
+            </Button>
+          ))}
+        </Box>
+      </Box>
+
+      <Box
+        css={css`
+          flex-grow: 1;
+          overflow-y: auto;
+          padding: 0 16px 16px;
+        }
+        `}
+      >
+        <CardContent />
+      </Box>
+
+      {/* 모달 */}
+      <FilterMultiSelectModal
+        open={modalType === 'job'}
+        onClose={closeModal}
+        title="직무"
+        items={jobOptions}
+        selectedItems={jobFilter}
+        onChange={setJobFilter}
+        multiSelect
+        hasSelectAll
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'education'}
+        onClose={closeModal}
+        title="학력 선택"
+        items={educationOptions}
+        selectedItems={educationFilter}
+        onChange={setEducationFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'age'}
+        onClose={closeModal}
+        title="연령대 선택"
+        items={ageOptions}
+        selectedItems={ageFilter}
+        onChange={setAgeFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'experience'}
+        onClose={closeModal}
+        title="경력 선택"
+        items={experienceOptions}
+        selectedItems={experienceFilter}
+        onChange={setExperienceFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'region'}
+        onClose={closeModal}
+        title="근무 지역 선택"
+        items={regionOptions}
+        selectedItems={regionFilter}
+        onChange={setRegionFilter}
+        multiSelect
+      />
+    </Box>
+  );
+};
+
+export default RecruiterPage;

--- a/src/routes/pages/RecuiterPage.tsx
+++ b/src/routes/pages/RecuiterPage.tsx
@@ -1,0 +1,191 @@
+import { css, Box, Button, Typography, useTheme } from '@mui/material';
+import DefaultHeader from '@components/headers/DefaultHeader';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useState } from 'react';
+import FilterMultiSelectModal from '@components/RecuiterPage/FilterModal';
+import CardContent from '@components/RecuiterPage/CardContent'; // 👉 여기서 CardContent는 talent list 포함한 리스트 출력 컴포넌트!
+
+const jobOptions = [
+  '프론트엔드 개발자', '백엔드 개발자', '풀스택 개발자', 'AI/머신러닝 엔지니어',
+  '클라우드 엔지니어', 'DevOps 엔지니어', '데이터 엔지니어', '모바일 앱 개발자',
+  '임베디드 시스템 개발자', '블록체인 개발자', '프로덕트 디자이너', '그래픽 디자이너',
+  '웹디자이너', '프로젝트 매니저', '데이터 분석가', '마케터', '학생', '취업 준비생', '연구원'
+];
+
+const educationOptions = ['고등학교 졸업', '2~3년제 졸업', '4년제 졸업', '대학원 석/박사'];
+
+const ageOptions = ['20~24세 이하', '25~29세 이하', '30~34세 이하', '35세 이상'];
+
+const experienceOptions = ['신입', '1~2년 이하', '3~4년 이하', '5년 이상'];
+
+const regionOptions = [
+  '수도권', '부산광역시', '대구광역시', '대전광역시', '광주광역시', '울산광역시',
+  '세종특별자치시', '강원권', '충청권', '전라권', '경상권', '제주특별자치도'
+];
+
+const RecuiterPage = () => {
+  const { palette, typo } = useTheme();
+
+  const [jobFilter, setJobFilter] = useState<string[]>([]);
+  const [educationFilter, setEducationFilter] = useState<string[]>([]);
+  const [ageFilter, setAgeFilter] = useState<string[]>([]);
+  const [experienceFilter, setExperienceFilter] = useState<string[]>([]);
+  const [regionFilter, setRegionFilter] = useState<string[]>([]);
+
+  const [modalType, setModalType] = useState<string | null>(null);
+
+  const openModal = (type: string) => setModalType(type);
+  const closeModal = () => setModalType(null);
+  
+  return (
+    <Box
+      css={css`
+        position: fixed;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100%;
+        max-width: 600px;
+        height: 100%;
+        background-color: ${palette.background.primary};
+        display: flex;
+        flex-direction: column;
+      `}
+    >
+      <DefaultHeader backgroundColor={palette.background.primary} />
+
+      <Box
+        css={css`
+          padding: 24px 16px 0;
+          flex-shrink: 0;
+        `}
+      >
+        <Typography
+          css={css`
+            font-size: 26px;
+            font-weight: bold;
+            margin-bottom: 8px;
+            font-family: ${typo.fontFamily.Pretendard};
+            color: ${palette.text.primary};
+          `}
+        >
+          인재 둘러보기
+        </Typography>
+        <Typography
+          css={css`
+            font-size: 16px;
+            color: ${palette.text.secondary};
+            ${typo.body.l};
+          `}
+        >
+          우리 회사에 적합한 인재를 저장해보세요.
+        </Typography>
+
+        <Box
+          css={css`
+            display: flex;
+            overflow-x: auto;
+            gap: 8px;
+            margin-bottom: 24px;
+            margin-top: 10px;
+            padding-bottom: 8px;
+            &::-webkit-scrollbar {
+              display: none;
+            }
+          `}
+        >
+          {[
+            { label: '직무', type: 'job' },
+            { label: '학력', type: 'education' },
+            { label: '연령대', type: 'age' },
+            { label: '경력', type: 'experience' },
+            { label: '희망 근무지', type: 'region' },
+          ].map(({ label, type }) => (
+            <Button
+              key={type}
+              onClick={() => openModal(type)}
+              variant="contained"
+              endIcon={
+                <ExpandMoreIcon
+                  sx={{ fontSize: 18, color: palette.text.primary }}
+                />
+              }
+              css={css`
+                flex-shrink: 0;
+                background-color: ${palette.background.secondary};
+                color: ${palette.text.secondary};
+                border-radius: 18px;
+                border: none;
+                padding: 6px 12px;
+                font-weight: 600;
+                font-size: 14px;
+                text-transform: none;
+              `}
+            >
+              {label}
+            </Button>
+          ))}
+        </Box>
+      </Box>
+
+      <Box
+        css={css`
+          flex-grow: 1;
+          overflow-y: auto;
+          padding: 0 16px 80px;
+          &::-webkit-scrollbar {
+          display: none;
+        }
+        `}
+      >
+        <CardContent />
+      </Box>
+
+      {/* 모달 */}
+      <FilterMultiSelectModal
+        open={modalType === 'job'}
+        onClose={closeModal}
+        title="직무"
+        items={jobOptions}
+        selectedItems={jobFilter}
+        onChange={setJobFilter}
+        multiSelect
+        hasSelectAll
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'education'}
+        onClose={closeModal}
+        title="학력 선택"
+        items={educationOptions}
+        selectedItems={educationFilter}
+        onChange={setEducationFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'age'}
+        onClose={closeModal}
+        title="연령대 선택"
+        items={ageOptions}
+        selectedItems={ageFilter}
+        onChange={setAgeFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'experience'}
+        onClose={closeModal}
+        title="경력 선택"
+        items={experienceOptions}
+        selectedItems={experienceFilter}
+        onChange={setExperienceFilter}
+      />
+      <FilterMultiSelectModal
+        open={modalType === 'region'}
+        onClose={closeModal}
+        title="근무 지역 선택"
+        items={regionOptions}
+        selectedItems={regionFilter}
+        onChange={setRegionFilter}
+        multiSelect
+      />
+    </Box>
+  );
+};
+
+export default RecuiterPage;


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/recuiter` → `dev`
<br/>

## ✅ 작업 내용

- 채용담당자 대시보드 구현 (필터, 카드 컴포넌트)
- 채용담당자 마이페이지 구현
- recruiter인데 recuiter라고 써서 오타 수정

<br/>

## 🌠 이미지 첨부

https://github.com/user-attachments/assets/76b8b72c-a4e4-4e96-86f0-1d8287260a25


<br/>
