### PR TITLE
feat(attendee): 참가자 관련 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mui-file-input": "^6.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-error-boundary": "^5.0.0",
         "react-router-dom": "^7.2.0",
         "zod": "^3.24.2",
         "zustand": "^5.0.3"
@@ -4275,6 +4276,18 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mui-file-input": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-error-boundary": "^5.0.0",
     "react-router-dom": "^7.2.0",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"

--- a/src/api/attendee-controller/fetchAttendeeDetailInfo.ts
+++ b/src/api/attendee-controller/fetchAttendeeDetailInfo.ts
@@ -1,0 +1,11 @@
+import apiClient from '@utils/axios';
+
+export const fetchAttendeeDetailInfo = async (attendeeId: number | null) => {
+  try {
+    const res = await apiClient.get(`/api/v1/attendee/${attendeeId}`);
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};

--- a/src/api/attendee-controller/fetchLinkedRecruiters.ts
+++ b/src/api/attendee-controller/fetchLinkedRecruiters.ts
@@ -1,0 +1,11 @@
+import apiClient from '@utils/axios';
+
+export const fetchLinkedRecruiters = async () => {
+  try {
+    const res = await apiClient.get('/api/v1/attendee/liked-recruiters');
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};

--- a/src/api/attendee-controller/index.ts
+++ b/src/api/attendee-controller/index.ts
@@ -20,16 +20,6 @@ export const fetchAttendeeDetailInfo = async (attendeeId: number) => {
   }
 };
 
-export const fetchLinkedRecruiters = async () => {
-  try {
-    const res = await apiClient.get('/api/v1/attendee/liked-recruiters');
-    return res.data;
-  } catch (err) {
-    console.log(err);
-    return Promise.reject(err);
-  }
-};
-
 export const patchOnboardingInfos = async () => {
   try {
     const res = await apiClient.patch('/api/v1/attendee/onboarding/job-info', {

--- a/src/api/attendee-controller/index.ts
+++ b/src/api/attendee-controller/index.ts
@@ -10,16 +10,6 @@ export const fetchMyProfile = async () => {
   }
 };
 
-export const fetchAttendeeDetailInfo = async (attendeeId: number) => {
-  try {
-    const res = await apiClient.get(`/api/v1/attendee/${attendeeId}`);
-    return res.data;
-  } catch (err) {
-    console.log(err);
-    return Promise.reject(err);
-  }
-};
-
 export const patchOnboardingInfos = async () => {
   try {
     const res = await apiClient.patch('/api/v1/attendee/onboarding/job-info', {

--- a/src/api/attendee-controller/index.ts
+++ b/src/api/attendee-controller/index.ts
@@ -1,0 +1,73 @@
+import apiClient from '@utils/axios';
+
+export const fetchMyProfile = async () => {
+  try {
+    const res = await apiClient.get('/api/v1/attendee/my');
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};
+
+export const fetchAttendeeDetailInfo = async (attendeeId: number) => {
+  try {
+    const res = await apiClient.get(`/api/v1/attendee/${attendeeId}`);
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};
+
+export const fetchLinkedRecruiters = async () => {
+  try {
+    const res = await apiClient.get('/api/v1/attendee/liked-recruiters');
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};
+
+export const patchOnboardingInfos = async () => {
+  try {
+    const res = await apiClient.patch('/api/v1/attendee/onboarding/job-info', {
+      'interestCodes': [0],
+      'jobGroupCode': 0,
+      'jobPositionCode': 0,
+      'hiringInterested': true,
+    });
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};
+
+export const patchOnboardingDetails = async () => {
+  try {
+    const res = await apiClient.patch(
+      '/api/v1/attendee/onboarding/job-info-details',
+      {
+        'desiredJobGroupCode': 0,
+        'desiredJobPositionCode': 0,
+        'educationLevelCode': 0,
+        'ageGroupCode': 0,
+        'techStacks': 'string',
+        'experienceLevelCode': 0,
+        'preferredRegionCodes': [0],
+        'selfIntroduction': 'string',
+        'profileImageUrl': 'string',
+        'additionalInfo': 'string',
+        'workplaceSelectionFactorCodes': [0],
+        'preferredCorporateCultureCodes': [0],
+        'conferencePurposeCodes': [0],
+      },
+    );
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};

--- a/src/api/point-controller/fetchMyPoints.ts
+++ b/src/api/point-controller/fetchMyPoints.ts
@@ -1,0 +1,11 @@
+import apiClient from '@utils/axios';
+
+export const fetchMyPoints = async () => {
+  try {
+    const res = await apiClient.get('/api/v1/points/my-points');
+    return res.data;
+  } catch (err) {
+    console.log(err);
+    return Promise.reject(err);
+  }
+};

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface FallbackProps {
+  error?: Error;
+  resetError?: () => void;
+}
+
+const ErrorFallback: React.FC<FallbackProps> = ({ error, resetError }) => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    resetError?.();
+    navigate('/login');
+  }, [navigate, resetError]);
+
+  return <></>;
+};
+
+export default ErrorFallback;

--- a/src/components/Mypage/ActionColumn.tsx
+++ b/src/components/Mypage/ActionColumn.tsx
@@ -13,7 +13,7 @@ const ActionColumn = ({ onClick, text }: Props) => {
       css={css`
         ${typo.sub.s}
         display: flex;
-        padding: 21.5px 16px;
+        padding: 20.5px 16px;
         justify-content: space-between;
         align-items: center;
         align-self: stretch;

--- a/src/components/Mypage/CompanyList.tsx
+++ b/src/components/Mypage/CompanyList.tsx
@@ -1,6 +1,15 @@
 import { css, Typography, useTheme } from '@mui/material';
 
-const CompanyList = () => {
+type RecruiterType = {
+  company: string;
+  responsibility: string;
+  name: string;
+};
+interface Props {
+  data: RecruiterType[];
+}
+
+const CompanyList = ({ data }: Props) => {
   const { palette, typo } = useTheme();
   const styles = {
     container: css`
@@ -37,8 +46,9 @@ const CompanyList = () => {
       </Typography>
 
       <div css={styles.content}>
-        <Column title="CodeSphere" desc="HR팀 매니저, 박수진" />
-        <Column title="OpenStack Korea" desc="HR팀 매니저, 김주은" />
+        {data.map((item, idx) => (
+          <Column key={idx} {...item} />
+        ))}
       </div>
     </div>
   );
@@ -46,11 +56,7 @@ const CompanyList = () => {
 
 export default CompanyList;
 
-interface ColumnProps {
-  title: string;
-  desc: string;
-}
-const Column = (props: ColumnProps) => {
+const Column = ({ company, responsibility, name }: RecruiterType) => {
   const { palette, typo } = useTheme();
   const styles = {
     container: css`
@@ -69,8 +75,10 @@ const Column = (props: ColumnProps) => {
   };
   return (
     <div css={styles.container}>
-      <span css={styles.title}>{props.title}</span>
-      <span css={styles.desc}>{props.title}</span>
+      <span css={styles.title}>{company}</span>
+      <span css={styles.desc}>
+        {responsibility} {name}
+      </span>
     </div>
   );
 };

--- a/src/components/Mypage/Information.tsx
+++ b/src/components/Mypage/Information.tsx
@@ -1,7 +1,20 @@
 import { Button, css, Typography, useTheme } from '@mui/material';
 import ImageModifier from './ImageModifier';
+import { POINT_SYSTEM } from 'src/constant/point-system';
 
-const Information = ({ buttonClick }: { buttonClick: () => void }) => {
+interface Props {
+  membershipLevel: 'BRONZE' | 'SILVER' | 'GOLD' | 'PLATINUM';
+  name: string;
+  totalPoints: number;
+  buttonClick: () => void;
+}
+
+const Information = ({
+  membershipLevel,
+  name,
+  totalPoints,
+  buttonClick,
+}: Props) => {
   const { palette, typo, radius } = useTheme();
 
   return (
@@ -22,17 +35,25 @@ const Information = ({ buttonClick }: { buttonClick: () => void }) => {
             margin-top: 2px;
           `}
         >
-          김지원 님, 반갑습니다.
+          {name} 님, 반갑습니다.
         </Typography>
         <Typography
           variant="h3"
           css={css`
+            display: flex;
+            align-items: center;
             ${typo.title.xs}
             color: ${palette.text.primary};
             margin: 8px 0px 4px;
           `}
         >
-          BRONZE 250P
+          <img
+            src={POINT_SYSTEM[membershipLevel].image}
+            width={26}
+            height={30}
+            css={{ padding: '1px 5px', boxSizing: 'content-box' }}
+          />{' '}
+          {membershipLevel} {totalPoints}P
         </Typography>
         <Typography
           variant="h3"

--- a/src/components/Mypage/MyPoint.tsx
+++ b/src/components/Mypage/MyPoint.tsx
@@ -1,6 +1,16 @@
 import { css, Typography, useTheme } from '@mui/material';
 
-const MyPoint = () => {
+type PointLogType = {
+  createdTime: string;
+  details: string;
+  point: number;
+  title: string;
+};
+interface Props {
+  data: PointLogType[];
+}
+
+const MyPoint = ({ data }: Props) => {
   const { palette, typo } = useTheme();
   const styles = {
     container: css`
@@ -31,6 +41,7 @@ const MyPoint = () => {
       padding: 10px 0px;
     `,
   };
+
   return (
     <div css={styles.container}>
       <Typography variant="h2" css={styles.title}>
@@ -44,11 +55,9 @@ const MyPoint = () => {
       </Typography>
 
       <div css={styles.content}>
-        <Column title="부스 방문" desc="OpenStack Korea" point={20} />
-        <Column title="부스 방문" desc="OpenStack Korea" point={20} />
-        <Column title="부스 방문" desc="OpenStack Korea" point={20} />
-        <Column title="부스 방문" desc="OpenStack Korea" point={20} />
-        <Column title="부스 방문" desc="OpenStack Korea" point={20} />
+        {data.map((item, idx) => (
+          <Column key={idx} {...item} />
+        ))}
       </div>
     </div>
   );
@@ -56,12 +65,7 @@ const MyPoint = () => {
 
 export default MyPoint;
 
-interface ColumnProps {
-  title: string;
-  desc: string;
-  point: number;
-}
-const Column = (props: ColumnProps) => {
+const Column = ({ createdTime, details, point, title }: PointLogType) => {
   const { palette, typo } = useTheme();
   const styles = {
     container: css`
@@ -89,10 +93,10 @@ const Column = (props: ColumnProps) => {
   return (
     <div css={styles.container}>
       <div css={styles.inner}>
-        <span css={styles.title}>{props.title}</span>
-        <span css={styles.desc}>{props.title}</span>
+        <span css={styles.title}>{title}</span>
+        <span css={styles.desc}>{details}</span>
       </div>
-      <div css={styles.point}>+{props.point}P</div>
+      <div css={styles.point}>+{point}P</div>
     </div>
   );
 };

--- a/src/components/Mypage/RecentPoints.tsx
+++ b/src/components/Mypage/RecentPoints.tsx
@@ -1,53 +1,40 @@
-import { css, useTheme } from '@mui/material';
+import { Box, css, useTheme } from '@mui/material';
 
-const RecentPoints = () => {
-  const json = {
-    data: [
-      {
-        title: '부스 방문',
-        desc: 'OpenStack Korea',
-        point: 20,
-      },
-      {
-        title: '세션 참여',
-        desc: '디지털 시대의 리더십과 팀 빌딩',
-        point: 30,
-      },
-      {
-        title: '부스 방문',
-        desc: 'CodeSphere',
-        point: 20,
-      },
-    ],
-  };
+type PointLogType = {
+  createdTime: string;
+  details: string;
+  point: number;
+  title: string;
+};
+interface Props {
+  data: PointLogType[];
+}
+
+const RecentPoints = ({ data }: Props) => {
+  const { palette } = useTheme();
+
   return (
-    <>
-      {json.data.map((item) => (
-        <Column {...item} />
+    <Box width={'100%'} borderBottom={`1px solid ${palette.border.primary}`}>
+      {data.map((item, idx) => (
+        <Column key={idx} {...item} />
       ))}
-    </>
+    </Box>
   );
 };
 
 export default RecentPoints;
 
-interface Props {
-  title: string;
-  desc: string;
-  point: number;
-}
-const Column = ({ title, desc, point = 0 }: Props) => {
+const Column = ({ createdTime, details, point, title }: PointLogType) => {
   const { palette, typo } = useTheme();
 
   return (
     <div
       css={css`
         display: flex;
-        padding: 14px 16px;
+        padding: 18px 16px;
         justify-content: space-between;
         align-items: center;
         align-self: stretch;
-        border-bottom: 1px solid ${palette.border.primary};
         width: 100%;
       `}
     >
@@ -71,7 +58,7 @@ const Column = ({ title, desc, point = 0 }: Props) => {
             color: ${palette.text.secondary};
           `}
         >
-          {desc}
+          {details}
         </span>
       </div>
       <span

--- a/src/routes/pages/MyInfo.tsx
+++ b/src/routes/pages/MyInfo.tsx
@@ -1,35 +1,28 @@
 import BackHeader from '@components/headers/BackHeader';
 import BasicInformation from '@components/MyInfoPage/BasicInformation';
 import OtherInformation from '@components/MyInfoPage/OtherInformation';
-import { Box, styled, useTheme } from '@mui/material';
+import { styled, useTheme } from '@mui/material';
+import { useAuthStore } from '@stores/client/useAuthStore';
+import { useAttendeeDetailInfo } from '@stores/server/attendee';
 import { useNavigate } from 'react-router-dom';
-
-const json = {
-  data: {
-    basic: {
-      name: '김지원',
-      jobName: '백엔드 개발자',
-      experience: '2년 이하',
-      image: 'https://placehold.co/130x160/png',
-    },
-    others: {
-      education: '4년제 대학 졸업',
-      ageGroup: '20-24세 이하',
-      techStacks:
-        'Java, AWS, Spring Boot, MySQL, Docker, JPA, github-actions, SonarQube, Redis, junit5, Mockito, Git',
-      desiredWorkRegion: '서울,경기',
-      selfIntroduction:
-        '저는 최신 기술을 배우고 IT 업계에서 성장하기 위해 다양한 컨퍼런스와 개발 프로젝트에 참여해왔습니다. 컴퓨터공학 전공자로서 웹 애플리케이션 개발과 데이터베이스 설계 경험이 있으며, 협업과 문제 해결 역량을 갖추고 있습니다. 여러 해커톤과 오픈소스 프로젝트에 참여하며 실무 감각을 익혔고, 컨퍼런스를 통해 업계 트렌드를 학습하며 네트워킹을 적극적으로 활용해왔습니다. 앞으로 데이터 분석과 AI 기술을 활용하여 가치 있는 서비스를 개발하고, 변화하는 환경 속에서 끊임없이 성장하는 개발자가 되고 싶습니다. 이번 기회를 통해 실무 경험을 쌓으며, IT 업계에서 더욱 발전할 수 있도록 최선을 다하겠습니다.',
-      information: 'lorem',
-      workplaceSelectionFactors: 'lorem',
-      preferredCorporateCultures: 'lorem',
-    },
-  },
-};
 
 const MyInfo = () => {
   const { palette } = useTheme();
   const navigate = useNavigate();
+
+  useAuthStore.getState().setAuth({
+    'accessToken': import.meta.env.VITE_AUTH_TOKEN,
+    'identifier': 'jiwon.kim@example.com',
+    'role': 'ATTENDEE',
+    'id': 1,
+  });
+
+  const {
+    data: { data },
+  } = useAttendeeDetailInfo({
+    identifier: useAuthStore.getState().user.identifier,
+    id: useAuthStore.getState().user.id,
+  });
 
   return (
     <>
@@ -38,8 +31,8 @@ const MyInfo = () => {
         onClick={() => navigate(-1)}
       />
       <Container>
-        <BasicInformation {...json.data.basic} />
-        <OtherInformation {...json.data.others} />
+        <BasicInformation {...data.baseInfo} />
+        <OtherInformation {...data.detailInfo} />
       </Container>
     </>
   );

--- a/src/routes/pages/MyInfo.tsx
+++ b/src/routes/pages/MyInfo.tsx
@@ -4,7 +4,7 @@ import OtherInformation from '@components/MyInfoPage/OtherInformation';
 import { styled, useTheme } from '@mui/material';
 import { useAuthStore } from '@stores/client/useAuthStore';
 import { useAttendeeDetailInfo } from '@stores/server/attendee';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const MyInfo = () => {
   const { palette } = useTheme();
@@ -17,12 +17,9 @@ const MyInfo = () => {
     'id': 1,
   });
 
-  const {
-    data: { data },
-  } = useAttendeeDetailInfo({
-    identifier: useAuthStore.getState().user.identifier,
-    id: useAuthStore.getState().user.id,
-  });
+  const { id } = useParams();
+
+  const { data: detailInfo } = useAttendeeDetailInfo(Number(id));
 
   return (
     <>
@@ -31,8 +28,8 @@ const MyInfo = () => {
         onClick={() => navigate(-1)}
       />
       <Container>
-        <BasicInformation {...data.baseInfo} />
-        <OtherInformation {...data.detailInfo} />
+        <BasicInformation {...detailInfo.data.baseInfo} />
+        <OtherInformation {...detailInfo.data.detailInfo} />
       </Container>
     </>
   );

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -8,7 +8,11 @@ import RecentPoints from '@components/Mypage/RecentPoints';
 import { styled } from '@mui/material';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useAttendeePoints, useAttendeeProfile } from '@stores/server/attendee';
+import {
+  useAttendeeLinkedRecruiters,
+  useAttendeePoints,
+  useAttendeeProfile,
+} from '@stores/server/attendee';
 
 type ModalType = 'point-system' | 'my-point' | 'company-list' | null;
 
@@ -17,6 +21,7 @@ const Mypage = () => {
   const navigate = useNavigate();
   const { data: myData } = useAttendeeProfile();
   const { data: myPoints } = useAttendeePoints();
+  const { data: myRecruiters } = useAttendeeLinkedRecruiters();
 
   return (
     <Wrapper>
@@ -37,7 +42,7 @@ const Mypage = () => {
           <>
             <ActionColumn
               onClick={() => setModalOpen('company-list')}
-              text="내 정보를 열람한 기업 (5)"
+              text={`내 정보를 열람한 기업 (${myRecruiters.data.length})`}
             />
             <ActionColumn
               onClick={() => navigate(`/my-info/${myData.data.attendeeId}`)}
@@ -69,7 +74,7 @@ const Mypage = () => {
         open={modalOpen === 'company-list'}
         onClose={() => setModalOpen(null)}
       >
-        <CompanyList />
+        <CompanyList data={myRecruiters.data} />
       </AnimatedModal>
     </Wrapper>
   );

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -10,21 +10,24 @@ import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
 import ErrorFallback from '@components/ErrorFallback';
+import { useAttendeeProfile } from '@stores/server/attendee';
 
 type ModalType = 'point-system' | 'my-point' | 'company-list' | null;
-
-const id = '1';
 
 const Mypage = () => {
   const [modalOpen, setModalOpen] = useState<ModalType>(null);
   const navigate = useNavigate();
+  const { data: myData } = useAttendeeProfile();
 
   return (
     <ErrorBoundary fallback={<ErrorFallback />}>
       <Wrapper>
         <TopContainer>
           <HeaderText>F’LINK 2025</HeaderText>
-          <Information buttonClick={() => setModalOpen('point-system')} />
+          <Information
+            {...myData.data}
+            buttonClick={() => setModalOpen('point-system')}
+          />
         </TopContainer>
         <BottomContainer>
           <ActionColumn
@@ -32,14 +35,19 @@ const Mypage = () => {
             text="포인트 적립 내역"
           />
           <RecentPoints />
-          <ActionColumn
-            onClick={() => setModalOpen('company-list')}
-            text="내 정보를 열람한 기업 (5)"
-          />
-          <ActionColumn
-            onClick={() => navigate(`/my-info/${id}`)}
-            text="내 정보 보기"
-          />
+          {myData.data.isHiringInterested && (
+            <>
+              <ActionColumn
+                onClick={() => setModalOpen('company-list')}
+                text="내 정보를 열람한 기업 (5)"
+              />
+              <ActionColumn
+                onClick={() => navigate(`/my-info/${myData.data.attendeeId}`)}
+                text="내 정보 보기"
+              />
+            </>
+          )}
+
           <ActionColumn onClick={() => {}} text="비밀번호 변경" />
           <ActionColumn onClick={() => {}} text="로그아웃" />
         </BottomContainer>

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -7,7 +7,9 @@ import PointSystem from '@components/Mypage/PointSystem';
 import RecentPoints from '@components/Mypage/RecentPoints';
 import { styled } from '@mui/material';
 import { useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
+import ErrorFallback from '@components/ErrorFallback';
 
 type ModalType = 'point-system' | 'my-point' | 'company-list' | null;
 
@@ -18,51 +20,53 @@ const Mypage = () => {
   const navigate = useNavigate();
 
   return (
-    <Wrapper>
-      <TopContainer>
-        <HeaderText>F’LINK 2025</HeaderText>
-        <Information buttonClick={() => setModalOpen('point-system')} />
-      </TopContainer>
-      <BottomContainer>
-        <ActionColumn
-          onClick={() => setModalOpen('my-point')}
-          text="포인트 적립 내역"
-        />
-        <RecentPoints />
-        <ActionColumn
-          onClick={() => setModalOpen('company-list')}
-          text="내 정보를 열람한 기업 (5)"
-        />
-        <ActionColumn
-          onClick={() => navigate(`/my-info/${id}`)}
-          text="내 정보 보기"
-        />
-        <ActionColumn onClick={() => {}} text="비밀번호 변경" />
-        <ActionColumn onClick={() => {}} text="로그아웃" />
-      </BottomContainer>
+    <ErrorBoundary fallback={<ErrorFallback />}>
+      <Wrapper>
+        <TopContainer>
+          <HeaderText>F’LINK 2025</HeaderText>
+          <Information buttonClick={() => setModalOpen('point-system')} />
+        </TopContainer>
+        <BottomContainer>
+          <ActionColumn
+            onClick={() => setModalOpen('my-point')}
+            text="포인트 적립 내역"
+          />
+          <RecentPoints />
+          <ActionColumn
+            onClick={() => setModalOpen('company-list')}
+            text="내 정보를 열람한 기업 (5)"
+          />
+          <ActionColumn
+            onClick={() => navigate(`/my-info/${id}`)}
+            text="내 정보 보기"
+          />
+          <ActionColumn onClick={() => {}} text="비밀번호 변경" />
+          <ActionColumn onClick={() => {}} text="로그아웃" />
+        </BottomContainer>
 
-      {/* 모달 */}
-      <AnimatedModal
-        open={modalOpen === 'point-system'}
-        onClose={() => setModalOpen(null)}
-      >
-        <PointSystem />
-      </AnimatedModal>
+        {/* 모달 */}
+        <AnimatedModal
+          open={modalOpen === 'point-system'}
+          onClose={() => setModalOpen(null)}
+        >
+          <PointSystem />
+        </AnimatedModal>
 
-      <AnimatedModal
-        open={modalOpen === 'my-point'}
-        onClose={() => setModalOpen(null)}
-      >
-        <MyPoint />
-      </AnimatedModal>
+        <AnimatedModal
+          open={modalOpen === 'my-point'}
+          onClose={() => setModalOpen(null)}
+        >
+          <MyPoint />
+        </AnimatedModal>
 
-      <AnimatedModal
-        open={modalOpen === 'company-list'}
-        onClose={() => setModalOpen(null)}
-      >
-        <CompanyList />
-      </AnimatedModal>
-    </Wrapper>
+        <AnimatedModal
+          open={modalOpen === 'company-list'}
+          onClose={() => setModalOpen(null)}
+        >
+          <CompanyList />
+        </AnimatedModal>
+      </Wrapper>
+    </ErrorBoundary>
   );
 };
 

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -13,12 +13,21 @@ import {
   useAttendeePoints,
   useAttendeeProfile,
 } from '@stores/server/attendee';
+import { useAuthStore } from '@stores/client/useAuthStore';
 
 type ModalType = 'point-system' | 'my-point' | 'company-list' | null;
 
 const Mypage = () => {
   const [modalOpen, setModalOpen] = useState<ModalType>(null);
   const navigate = useNavigate();
+
+  useAuthStore.getState().setAuth({
+    'accessToken': import.meta.env.VITE_AUTH_TOKEN,
+    'identifier': 'jiwon.kim@example.com',
+    'role': 'ATTENDEE',
+    'id': 1,
+  });
+
   const { data: myData } = useAttendeeProfile();
   const { data: myPoints } = useAttendeePoints();
   const { data: myRecruiters } = useAttendeeLinkedRecruiters();

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -7,10 +7,8 @@ import PointSystem from '@components/Mypage/PointSystem';
 import RecentPoints from '@components/Mypage/RecentPoints';
 import { styled } from '@mui/material';
 import { useState } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
 import { useNavigate } from 'react-router-dom';
-import ErrorFallback from '@components/ErrorFallback';
-import { useAttendeeProfile } from '@stores/server/attendee';
+import { useAttendeePoints, useAttendeeProfile } from '@stores/server/attendee';
 
 type ModalType = 'point-system' | 'my-point' | 'company-list' | null;
 
@@ -18,63 +16,62 @@ const Mypage = () => {
   const [modalOpen, setModalOpen] = useState<ModalType>(null);
   const navigate = useNavigate();
   const { data: myData } = useAttendeeProfile();
+  const { data: myPoints } = useAttendeePoints();
 
   return (
-    <ErrorBoundary fallback={<ErrorFallback />}>
-      <Wrapper>
-        <TopContainer>
-          <HeaderText>F’LINK 2025</HeaderText>
-          <Information
-            {...myData.data}
-            buttonClick={() => setModalOpen('point-system')}
-          />
-        </TopContainer>
-        <BottomContainer>
-          <ActionColumn
-            onClick={() => setModalOpen('my-point')}
-            text="포인트 적립 내역"
-          />
-          <RecentPoints />
-          {myData.data.isHiringInterested && (
-            <>
-              <ActionColumn
-                onClick={() => setModalOpen('company-list')}
-                text="내 정보를 열람한 기업 (5)"
-              />
-              <ActionColumn
-                onClick={() => navigate(`/my-info/${myData.data.attendeeId}`)}
-                text="내 정보 보기"
-              />
-            </>
-          )}
+    <Wrapper>
+      <TopContainer>
+        <HeaderText>F’LINK 2025</HeaderText>
+        <Information
+          {...myData.data}
+          buttonClick={() => setModalOpen('point-system')}
+        />
+      </TopContainer>
+      <BottomContainer>
+        <ActionColumn
+          onClick={() => setModalOpen('my-point')}
+          text="포인트 적립 내역"
+        />
+        <RecentPoints data={myPoints.data.slice(0, 3)} />
+        {myData.data.isHiringInterested && (
+          <>
+            <ActionColumn
+              onClick={() => setModalOpen('company-list')}
+              text="내 정보를 열람한 기업 (5)"
+            />
+            <ActionColumn
+              onClick={() => navigate(`/my-info/${myData.data.attendeeId}`)}
+              text="내 정보 보기"
+            />
+          </>
+        )}
 
-          <ActionColumn onClick={() => {}} text="비밀번호 변경" />
-          <ActionColumn onClick={() => {}} text="로그아웃" />
-        </BottomContainer>
+        <ActionColumn onClick={() => {}} text="비밀번호 변경" />
+        <ActionColumn onClick={() => {}} text="로그아웃" />
+      </BottomContainer>
 
-        {/* 모달 */}
-        <AnimatedModal
-          open={modalOpen === 'point-system'}
-          onClose={() => setModalOpen(null)}
-        >
-          <PointSystem />
-        </AnimatedModal>
+      {/* 모달 */}
+      <AnimatedModal
+        open={modalOpen === 'point-system'}
+        onClose={() => setModalOpen(null)}
+      >
+        <PointSystem />
+      </AnimatedModal>
 
-        <AnimatedModal
-          open={modalOpen === 'my-point'}
-          onClose={() => setModalOpen(null)}
-        >
-          <MyPoint />
-        </AnimatedModal>
+      <AnimatedModal
+        open={modalOpen === 'my-point'}
+        onClose={() => setModalOpen(null)}
+      >
+        <MyPoint data={myPoints.data} />
+      </AnimatedModal>
 
-        <AnimatedModal
-          open={modalOpen === 'company-list'}
-          onClose={() => setModalOpen(null)}
-        >
-          <CompanyList />
-        </AnimatedModal>
-      </Wrapper>
-    </ErrorBoundary>
+      <AnimatedModal
+        open={modalOpen === 'company-list'}
+        onClose={() => setModalOpen(null)}
+      >
+        <CompanyList />
+      </AnimatedModal>
+    </Wrapper>
   );
 };
 

--- a/src/routes/pages/Mypage.tsx
+++ b/src/routes/pages/Mypage.tsx
@@ -60,7 +60,10 @@ const Mypage = () => {
           </>
         )}
 
-        <ActionColumn onClick={() => {}} text="비밀번호 변경" />
+        <ActionColumn
+          onClick={() => navigate('/reset-password')}
+          text="비밀번호 변경"
+        />
         <ActionColumn onClick={() => {}} text="로그아웃" />
       </BottomContainer>
 

--- a/src/stores/client/useAuthStore.ts
+++ b/src/stores/client/useAuthStore.ts
@@ -7,6 +7,7 @@ type UserAuthData = {
   accessToken: string | null;
   identifier: string | null;
   role: UserRole;
+  id: number | null;
 };
 
 interface AuthState {
@@ -15,14 +16,19 @@ interface AuthState {
   clearAuth: () => void;
 }
 
-const initialValue = { accessToken: null, identifier: null, role: null };
+const initialValue = {
+  accessToken: null,
+  identifier: null,
+  role: null,
+  id: null,
+};
 
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: initialValue,
-      setAuth: ({ accessToken, identifier, role }: UserAuthData) =>
-        set({ user: { accessToken, identifier, role } }),
+      setAuth: ({ accessToken, identifier, role, id }: UserAuthData) =>
+        set({ user: { accessToken, identifier, role, id } }),
       clearAuth: () => set({ user: initialValue }),
     }),
     {

--- a/src/stores/server/attendee/index.ts
+++ b/src/stores/server/attendee/index.ts
@@ -15,3 +15,11 @@ export const useAttendeeProfile = () => {
 
   return query;
 };
+
+export const useAttendeePoints = () => {
+  const query = useSuspenseQuery(
+    attendeeQueries.points(useAuthStore.getState().user.identifier),
+  );
+
+  return query;
+};

--- a/src/stores/server/attendee/index.ts
+++ b/src/stores/server/attendee/index.ts
@@ -3,44 +3,20 @@ import { attendeeQueries } from './queries';
 import { useAuthStore } from '@stores/client/useAuthStore';
 
 export const useAttendeeProfile = () => {
-  useAuthStore.getState().setAuth({
-    'accessToken': import.meta.env.VITE_AUTH_TOKEN,
-    'identifier': 'jiwon.kim@example.com',
-    'role': 'ATTENDEE',
-    'id': 1,
-  });
-
-  const query = useSuspenseQuery(
-    attendeeQueries.users(useAuthStore.getState().user.identifier),
-  );
-
-  return query;
+  const { identifier } = useAuthStore.getState().user;
+  return useSuspenseQuery(attendeeQueries.users(identifier));
 };
 
 export const useAttendeePoints = () => {
-  const query = useSuspenseQuery(
-    attendeeQueries.points(useAuthStore.getState().user.identifier),
-  );
-
-  return query;
+  const { identifier } = useAuthStore.getState().user;
+  return useSuspenseQuery(attendeeQueries.points(identifier));
 };
 
 export const useAttendeeLinkedRecruiters = () => {
-  const query = useSuspenseQuery(
-    attendeeQueries.linkedRecruiters(useAuthStore.getState().user.identifier),
-  );
-
-  return query;
+  const { identifier } = useAuthStore.getState().user;
+  return useSuspenseQuery(attendeeQueries.linkedRecruiters(identifier));
 };
 
-export const useAttendeeDetailInfo = ({
-  identifier,
-  id,
-}: {
-  identifier: string | null;
-  id: number | null;
-}) => {
-  const query = useSuspenseQuery(attendeeQueries.detailInfo(identifier, id));
-
-  return query;
+export const useAttendeeDetailInfo = (id: number) => {
+  return useSuspenseQuery(attendeeQueries.detailInfo(id));
 };

--- a/src/stores/server/attendee/index.ts
+++ b/src/stores/server/attendee/index.ts
@@ -10,7 +10,7 @@ export const useAttendeeProfile = () => {
   });
 
   const query = useSuspenseQuery(
-    attendeeQueries.user(useAuthStore.getState().user.identifier),
+    attendeeQueries.users(useAuthStore.getState().user.identifier),
   );
 
   return query;
@@ -19,6 +19,14 @@ export const useAttendeeProfile = () => {
 export const useAttendeePoints = () => {
   const query = useSuspenseQuery(
     attendeeQueries.points(useAuthStore.getState().user.identifier),
+  );
+
+  return query;
+};
+
+export const useAttendeeLinkedRecruiters = () => {
+  const query = useSuspenseQuery(
+    attendeeQueries.linkedRecruiters(useAuthStore.getState().user.identifier),
   );
 
   return query;

--- a/src/stores/server/attendee/index.ts
+++ b/src/stores/server/attendee/index.ts
@@ -1,0 +1,17 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { attendeeQueries } from './queries';
+import { useAuthStore } from '@stores/client/useAuthStore';
+
+export const useAttendeeProfile = () => {
+  useAuthStore.getState().setAuth({
+    'accessToken': import.meta.env.VITE_AUTH_TOKEN,
+    'identifier': 'jiwon.kim@example.com',
+    'role': 'ATTENDEE',
+  });
+
+  const query = useSuspenseQuery(
+    attendeeQueries.user(useAuthStore.getState().user.identifier),
+  );
+
+  return query;
+};

--- a/src/stores/server/attendee/index.ts
+++ b/src/stores/server/attendee/index.ts
@@ -7,6 +7,7 @@ export const useAttendeeProfile = () => {
     'accessToken': import.meta.env.VITE_AUTH_TOKEN,
     'identifier': 'jiwon.kim@example.com',
     'role': 'ATTENDEE',
+    'id': 1,
   });
 
   const query = useSuspenseQuery(
@@ -28,6 +29,18 @@ export const useAttendeeLinkedRecruiters = () => {
   const query = useSuspenseQuery(
     attendeeQueries.linkedRecruiters(useAuthStore.getState().user.identifier),
   );
+
+  return query;
+};
+
+export const useAttendeeDetailInfo = ({
+  identifier,
+  id,
+}: {
+  identifier: string | null;
+  id: number | null;
+}) => {
+  const query = useSuspenseQuery(attendeeQueries.detailInfo(identifier, id));
 
   return query;
 };

--- a/src/stores/server/attendee/queries.ts
+++ b/src/stores/server/attendee/queries.ts
@@ -1,4 +1,5 @@
 import { fetchMyProfile } from '@api/attendee-controller';
+import { fetchMyPoints } from '@api/point-controller/fetchMyPoints';
 import { queryOptions } from '@tanstack/react-query';
 
 export const attendeeQueries = {
@@ -7,5 +8,10 @@ export const attendeeQueries = {
     queryOptions({
       queryKey: [...attendeeQueries.all(), identifier],
       queryFn: () => fetchMyProfile(),
+    }),
+  points: (identifier: string | null) =>
+    queryOptions({
+      queryKey: [...attendeeQueries.all(), 'my-point', identifier],
+      queryFn: () => fetchMyPoints(),
     }),
 };

--- a/src/stores/server/attendee/queries.ts
+++ b/src/stores/server/attendee/queries.ts
@@ -1,17 +1,24 @@
 import { fetchMyProfile } from '@api/attendee-controller';
+import { fetchLinkedRecruiters } from '@api/attendee-controller/fetchLinkedRecruiters';
 import { fetchMyPoints } from '@api/point-controller/fetchMyPoints';
 import { queryOptions } from '@tanstack/react-query';
 
 export const attendeeQueries = {
   all: () => ['attendee'],
-  user: (identifier: string | null) =>
+  user: (identifier: string | null) => [...attendeeQueries.all(), identifier],
+  users: (identifier: string | null) =>
     queryOptions({
-      queryKey: [...attendeeQueries.all(), identifier],
+      queryKey: [...attendeeQueries.user(identifier)],
       queryFn: () => fetchMyProfile(),
     }),
   points: (identifier: string | null) =>
     queryOptions({
-      queryKey: [...attendeeQueries.all(), 'my-point', identifier],
+      queryKey: [...attendeeQueries.user(identifier), 'my-point'],
       queryFn: () => fetchMyPoints(),
+    }),
+  linkedRecruiters: (identifier: string | null) =>
+    queryOptions({
+      queryKey: [...attendeeQueries.user(identifier), 'linked-recruiters'],
+      queryFn: () => fetchLinkedRecruiters(),
     }),
 };

--- a/src/stores/server/attendee/queries.ts
+++ b/src/stores/server/attendee/queries.ts
@@ -1,0 +1,11 @@
+import { fetchMyProfile } from '@api/attendee-controller';
+import { queryOptions } from '@tanstack/react-query';
+
+export const attendeeQueries = {
+  all: () => ['attendee'],
+  user: (identifier: string | null) =>
+    queryOptions({
+      queryKey: [...attendeeQueries.all(), identifier],
+      queryFn: () => fetchMyProfile(),
+    }),
+};

--- a/src/stores/server/attendee/queries.ts
+++ b/src/stores/server/attendee/queries.ts
@@ -1,4 +1,5 @@
 import { fetchMyProfile } from '@api/attendee-controller';
+import { fetchAttendeeDetailInfo } from '@api/attendee-controller/fetchAttendeeDetailInfo';
 import { fetchLinkedRecruiters } from '@api/attendee-controller/fetchLinkedRecruiters';
 import { fetchMyPoints } from '@api/point-controller/fetchMyPoints';
 import { queryOptions } from '@tanstack/react-query';
@@ -20,5 +21,10 @@ export const attendeeQueries = {
     queryOptions({
       queryKey: [...attendeeQueries.user(identifier), 'linked-recruiters'],
       queryFn: () => fetchLinkedRecruiters(),
+    }),
+  detailInfo: (identifier: string | null, id: number | null) =>
+    queryOptions({
+      queryKey: [...attendeeQueries.user(identifier), 'detail-info', id],
+      queryFn: () => fetchAttendeeDetailInfo(id),
     }),
 };

--- a/src/stores/server/attendee/queries.ts
+++ b/src/stores/server/attendee/queries.ts
@@ -22,9 +22,9 @@ export const attendeeQueries = {
       queryKey: [...attendeeQueries.user(identifier), 'linked-recruiters'],
       queryFn: () => fetchLinkedRecruiters(),
     }),
-  detailInfo: (identifier: string | null, id: number | null) =>
+  detailInfo: (id: number | null) =>
     queryOptions({
-      queryKey: [...attendeeQueries.user(identifier), 'detail-info', id],
+      queryKey: ['detail-info', id],
       queryFn: () => fetchAttendeeDetailInfo(id),
     }),
 };


### PR DESCRIPTION
## 🚀 반영 브랜치
`feat/attendee-api` → `dev`

<br/>

## ✅ 작업 내용

- 마이페이지 프로필 api 연동
- 적립 포인트 내역 api 연동
- 내 정보 열람한 기업 api 연동
- 유저 세부 정보 api 연동
- 비밀번호 변경 라우팅 설정

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/92a21428-e64e-4739-8466-01ec1f7100cd)

<br/>

## ✏️ 앞으로의 과제

- 로그인 측 구현되면 mypage, myinfo 페이지 setAuth 삭제
