### PR TITLE
feat(admin): 컨퍼런스 서비스 참여자 수 api 연동

### DIFF
--- a/src/api/conference-controller/index.ts
+++ b/src/api/conference-controller/index.ts
@@ -1,0 +1,18 @@
+import apiClient from '@utils/axios';
+import { AxiosError } from 'axios';
+
+const CONFERENCE_ID = 1;
+
+// 세션,부스,컨퍼런스 참여자 조회
+export const fetchConferenceUsers = async () => {
+  try {
+    const res = await apiClient.get(`/api/v1/conference/${CONFERENCE_ID}`);
+    return res.data;
+  } catch (err) {
+    if (err instanceof AxiosError) {
+      if (err.status === 403 || err.status === 401)
+        return (window.location.href = '/');
+    }
+    return Promise.reject(err);
+  }
+};

--- a/src/components/AdminPage/UserCount.tsx
+++ b/src/components/AdminPage/UserCount.tsx
@@ -2,117 +2,103 @@ import { Box, Typography, Paper } from '@mui/material';
 import { css, useTheme } from '@mui/material';
 import { useState, useEffect } from 'react';
 import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import { useConferenceUsers } from '@stores/server/conference';
 
-const UserCount = ({ title, count }: { title: string; count?: number | string }) => {
-    const theme = useTheme();
+const UserCount = ({
+  title,
+  count,
+}: {
+  title: string;
+  count?: number | string;
+}) => {
+  const theme = useTheme();
 
-    return (
-        <Paper
-            css={css`
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                color: ${theme.palette.text.primary};
-                border-radius: ${theme.radius.md}px;
-                background-color: transparent;
-                border: 1px solid ${theme.palette.border.primary};
-                overflow: hidden;
-                width: 100%;
-                height: 60px;
-            `}
+  return (
+    <Paper
+      css={css`
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        color: ${theme.palette.text.primary};
+        border-radius: ${theme.radius.md}px;
+        background-color: transparent;
+        border: 1px solid ${theme.palette.border.primary};
+        overflow: hidden;
+        width: 100%;
+        height: 60px;
+      `}
+    >
+      <Box
+        css={css`
+          display: flex;
+          align-items: center;
+          padding-left: 12px;
+        `}
+      >
+        <PeopleAltIcon sx={{ color: theme.palette.text.quaternary }} />
+      </Box>
+      <Box
+        css={css`
+          flex-grow: 1;
+          padding: 14px 12px;
+        `}
+      >
+        <Typography
+          variant="body1"
+          css={css`
+            color: ${theme.palette.text.quaternary};
+            font-family: ${theme.typography.fontFamily};
+            font-size: 14px;
+            font-weight: 400;
+            line-height: normal;
+            overflow: hidden;
+            white-space: nowrap;
+          `}
         >
-            <Box
-                css={css`
-                    display: flex;
-                    align-items: center;
-                    padding-left: 12px;
-                `}
-            >
-                <PeopleAltIcon sx={{ color: theme.palette.text.quaternary }} />
-            </Box>
-            <Box
-                css={css`
-                    flex-grow: 1;
-                    padding: 14px 12px;
-                `}
-            >
-                <Typography
-                    variant="body1"
-                    css={css`
-                        color: ${theme.palette.text.quaternary};
-                        font-family: ${theme.typography.fontFamily};
-                        font-size: 14px;
-                        font-weight: 400;
-                        line-height: normal;
-                        overflow: hidden;
-                        white-space: nowrap;
-                    `}
-                >
-                    {title}
-                </Typography>
-                
-                <Typography
-                    variant="h6"
-                    css={css`
-                        color: #F5F5F5;
-                        font-family: ${theme.typography.fontFamily};
-                        font-size: 18px;
-                        font-style: normal;
-                        font-weight: 700;
-                        line-height: normal;
-                    `}
-                >
-                    {count ?? '정보 없음'}
-                </Typography>
-            </Box>
-        </Paper>
-    );
+          {title}
+        </Typography>
+
+        <Typography
+          variant="h6"
+          css={css`
+            color: #f5f5f5;
+            font-family: ${theme.typography.fontFamily};
+            font-size: 18px;
+            font-style: normal;
+            font-weight: 700;
+            line-height: normal;
+          `}
+        >
+          {count ?? '정보 없음'}
+        </Typography>
+      </Box>
+    </Paper>
+  );
 };
 
 const UserCounts = () => {
-    const [counts, setCounts] = useState<{
-        sessionCount?: number;
-        boothCount?: number;
-        eventCount?: number;
-        serviceCount?: number;
-    }>({
-        sessionCount: undefined,
-        boothCount: undefined,
-        eventCount: undefined,
-        serviceCount: undefined,
-    });
+  const {
+    data: { data: counts },
+  } = useConferenceUsers();
 
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                setCounts({
-                    sessionCount: 100,
-                    boothCount: 200,
-                    eventCount: 300,
-                    serviceCount: 400,
-                });
-            } catch (error) {
-                console.error('Failed to fetch user counts:', error);
-            }
-        };
-        fetchData();
-    }, []);
-
-    return (
-        <Box
-            css={css`
-                display: grid;
-                grid-template-columns: repeat(2, 1fr);
-                gap: 16px;
-                padding: 5px;
-            `}
-        >
-            <UserCount title="세션 참여자 수" count={counts.sessionCount} />
-            <UserCount title="부스 참여자 수" count={counts.boothCount} />
-            <UserCount title="행사 참가자 수" count={counts.eventCount} />
-            <UserCount title="서비스 가입자 수" count={counts.serviceCount} />
-        </Box>
-    );
+  return (
+    <Box
+      css={css`
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 16px;
+        padding: 5px;
+      `}
+    >
+      <UserCount title="세션 참여자 수" count={counts.sessionAttendeeCount} />
+      <UserCount title="부스 참여자 수" count={counts.boothAttendeeCount} />
+      <UserCount
+        title="행사 참가자 수"
+        count={counts.conferenceAttendeeCount}
+      />
+      <UserCount title="서비스 가입자 수" count={counts.serviceAttendeeCount} />
+    </Box>
+  );
 };
 
 export default UserCounts;

--- a/src/stores/server/conference/index.ts
+++ b/src/stores/server/conference/index.ts
@@ -1,5 +1,5 @@
-import { useMutation } from '@tanstack/react-query';
-import { createConferenceQuery } from './queries';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { conferenceQueries, createConferenceQuery } from './queries';
 
 export const useCreateConferenceMutation = () => {
   return useMutation({
@@ -12,4 +12,8 @@ export const useCreateConferenceMutation = () => {
       alert(error.message || '컨퍼런스 등록 중 오류가 발생했습니다.');
     },
   });
+};
+
+export const useConferenceUsers = () => {
+  return useSuspenseQuery(conferenceQueries.users());
 };

--- a/src/stores/server/conference/queries.ts
+++ b/src/stores/server/conference/queries.ts
@@ -1,6 +1,17 @@
+import { fetchConferenceUsers } from '@api/conference-controller';
 import { createConference } from '@api/conference-controller/createConference';
+import { queryOptions } from '@tanstack/react-query';
 
 export const createConferenceQuery = {
   queryKey: ['createConference'],
   queryFn: createConference,
+};
+
+export const conferenceQueries = {
+  all: () => ['conference'],
+  users: () =>
+    queryOptions({
+      queryKey: [...conferenceQueries.all(), 'users'],
+      queryFn: () => fetchConferenceUsers(),
+    }),
 };


### PR DESCRIPTION
## 🚀 반영 브랜치

`feat/admin` → `dev`

<br/>

## ✅ 작업 내용

- 대시보드 상단의 참여자수, 서비스 이용자 수 등등 유저 수에 관련한 api 조회 연동하였습니다.

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/2e5aee5b-da23-4824-9a7d-79dd6b466c39)
