### PR TITLE
feat(404): 404 페이지 구현

### DIFF
--- a/src/routes/pages/NotFound.tsx
+++ b/src/routes/pages/NotFound.tsx
@@ -1,3 +1,53 @@
+import { Box, Button, css, useTheme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
 export default function NotFound() {
-  return <h1>404 Page Not Found</h1>;
+  const { typo, palette } = useTheme();
+  const navigate = useNavigate();
+
+  const styles = {
+    title: css`
+      ${typo.title.l}
+      color: ${palette.text.primary};
+    `,
+    button: css`
+      border-radius: 12px;
+      height: 50px;
+      width: 160px;
+      flex: 1 0 0;
+      background-color: ${palette.background.tertiary};
+      color: ${palette.text.primary};
+      border: none;
+      ${typo.sub.s}
+    `,
+  };
+  return (
+    <Box
+      css={css`
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+        `}
+      >
+        <h1 css={styles.title}>404</h1>
+        <h1 css={styles.title}>페이지를 찾을 수 없습니다.</h1>
+      </div>
+      <div>
+        <Button css={styles.button} onClick={() => navigate('/')}>
+          돌아가기
+        </Button>
+      </div>
+    </Box>
+  );
 }


### PR DESCRIPTION

## 🚀 반영 브랜치

`feat/notfound` → `dev`

<br/>

## ✅ 작업 내용

- 404페이지를 구현하였습니다.
- 돌아가기를 클릭시 `/` 경로로 이동시킵니다.

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/fd485230-f7ce-40f7-968c-16ff5435cac8)
