### PR TITLE
fix(reset-password): 재설정 페이지 이동 제한

### DIFF
--- a/src/components/AccountPage/ResetPassword.tsx
+++ b/src/components/AccountPage/ResetPassword.tsx
@@ -261,7 +261,15 @@ const ResetPassword = (): React.JSX.Element => {
             </Grid>
 
             <Grid item xs={12}>
-              <Button onClick={() => setStep(2)} css={buttonStyle}>
+              <Button onClick={() => {
+                  if (!confirmAuthCodeMutation.isSuccess) {
+                    setFormError('이메일 인증을 완료해주세요.');
+                    return;
+                  }
+                  setStep(2);
+                }}
+                css={buttonStyle}
+              >
                 확인
               </Button>
             </Grid>


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/resetPassword` → `main`

<br/>

## ✅ 작업 내용

- 비밀번호 재입력하는 페이지 넘어가기 전 이메일 인증이 완료되야만 넘어갈 수 있게로 수정

<br/>




## 🌠 이미지 첨부

[<img src="파일주소" width="50%" height="50%"/>](https://github.com/user-attachments/assets/99880797-0e00-46a6-9251-7ae979014c9c)

<br/>

## ✏️ 앞으로의 과제

- 로그인/ 온보딩 완료 후 mypage-> session
- 참가자 nav 위치 수정

