### PR TITLE
fix(route): 참가자 로그인 완료 라우트 변경, 네비게이션 바 수정

### DIFF
--- a/src/routes/layouts/DefaultNav.tsx
+++ b/src/routes/layouts/DefaultNav.tsx
@@ -33,14 +33,14 @@ export default DefaultNavLayout;
 const Navigation = () => {
   return (
     <Nav>
-      <CustomLink to="/booth">
-        <CustomButton>BOOTH</CustomButton>
+      <CustomLink to="/session">
+        <CustomButton>SESSION</CustomButton>
       </CustomLink>
       <CustomLink to="/mypage">
         <CustomButton>MY</CustomButton>
       </CustomLink>
-      <CustomLink to="/session">
-        <CustomButton>SESSION</CustomButton>
+      <CustomLink to="/booth">
+        <CustomButton>BOOTH</CustomButton>
       </CustomLink>
     </Nav>
   );

--- a/src/routes/pages/OnBoarding.tsx
+++ b/src/routes/pages/OnBoarding.tsx
@@ -114,7 +114,7 @@ const OnBoarding = () => {
                 if (work.employeement_agree === 'no') {
                   initForm();
                   if (redirectURL) navigate(redirectURL);
-                  else navigate('/mypage');
+                  else navigate('/session');
                 } else {
                   history.push('info', (prev) => ({ ...prev, work }));
                 }
@@ -140,7 +140,7 @@ const OnBoarding = () => {
                 initForm();
 
                 if (redirectURL) navigate(redirectURL);
-                else navigate('/mypage');
+                else navigate('/session');
               }}
             />
           )}

--- a/src/stores/server/auth/index.ts
+++ b/src/stores/server/auth/index.ts
@@ -29,7 +29,7 @@ export const useLoginMutation = () => {
         id: data.id,
       });
       const params = new URLSearchParams(location.search);
-      const redirectTo = params.get('redirectTo') || '/mypage';
+      const redirectTo = params.get('redirectTo') || '/session';
       navigate(redirectTo);
     },
     onError: (error: any) => {


### PR DESCRIPTION
## 🚀 반영 브랜치

`fix/attendee-route` → `main`

<br/>

## ✅ 작업 내용

- 로그인/ 온보딩 과정 후 `mypage`에서 `session`으로 이동
- 네비게이션 바 seesion / mypage / booth 순으로 변경

<br/>

## 🌠 이미지 첨부
https://github.com/user-attachments/assets/5fb6cc5b-10fb-4be3-bdb6-204a8da9d315

