### PR TITLE
fix(myinfo): 멀티셀렉 요소에 대하여 구분자 적용

### DIFF
--- a/src/components/MyInfoPage/OtherInformation.tsx
+++ b/src/components/MyInfoPage/OtherInformation.tsx
@@ -1,15 +1,14 @@
 import { Box, Typography, useTheme } from '@mui/material';
-import images from '@assets/default-profile-img.png';
 
 interface Props {
   education: string;
   ageGroup: string;
   techStacks: string;
-  desiredWorkRegion: string;
+  desiredWorkRegion: string[];
   selfIntroduction: string;
   information: string;
-  workplaceSelectionFactors: string;
-  preferredCorporateCultures: string;
+  workplaceSelectionFactors: string[];
+  preferredCorporateCultures: string[];
 }
 
 const OtherInformation = ({
@@ -34,16 +33,19 @@ const OtherInformation = ({
       <InfoColumn title="학력" content={education} />
       <InfoColumn title="연령대" content={ageGroup} />
       <InfoColumn title="보유 기술" content={techStacks} />
-      <InfoColumn title="희망 근무 지역" content={desiredWorkRegion} />
+      <InfoColumn
+        title="희망 근무 지역"
+        content={desiredWorkRegion.join(', ')}
+      />
       <InfoColumn title="자기소개" content={selfIntroduction} />
       <InfoColumn title="경험 및 기타 정보" content={information || '-'} />
       <InfoColumn
         title="직장 선택 요소"
-        content={workplaceSelectionFactors || '-'}
+        content={workplaceSelectionFactors.join(', ') || '-'}
       />
       <InfoColumn
         title="선호하는 기업 문화"
-        content={preferredCorporateCultures || '-'}
+        content={preferredCorporateCultures.join(', ') || '-'}
       />
     </Box>
   );


### PR DESCRIPTION
## 🚀 반영 브랜치

`hotfix/QA` → `main`

<br/>

## ✅ 작업 내용

- my-info 페이지 멀티 셀렉 요소에 대하여 구분자 적용하여 표시

<br/>

## 🌠 이미지 첨부

![image](https://github.com/user-attachments/assets/284cd833-abc0-4a2b-b014-229fd821abb2)