### PR TITLE
style(recruiter): 채용담당자 테마 적용

### DIFF
--- a/src/components/RecruiterPage/CardContent.tsx
+++ b/src/components/RecruiterPage/CardContent.tsx
@@ -4,7 +4,6 @@ import FavoriteIcon from '@mui/icons-material/Favorite';
 import { useRecruiterAttendees, useLikeAttendee, useUnlikeAttendee } from '@stores/server/recruiter';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { recruiterQueries } from '@stores/server/recruiter/queries';
 import { useLocation } from 'react-router-dom';
 
 interface CardContentProps {
@@ -30,11 +29,13 @@ const CardContent = ({ filters }: CardContentProps) => {
   });
 
   const location = useLocation();
-  const { palette } = useTheme();
   const likeMutation = useLikeAttendee();
   const unlikeMutation = useUnlikeAttendee();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const theme = useTheme();
+  const { palette, typo, radius } = theme;
 
   const truncateText = (text: string, length: number) => {
     if (text.length > length) {
@@ -63,7 +64,7 @@ const CardContent = ({ filters }: CardContentProps) => {
     navigate(`/my-info/${attendeeId}`);
   };
 
-  const isMypage = location.pathname === '/recruiter/mypage';
+  const isList = location.pathname === '/recruiter/list';
 
   return (
     <Box
@@ -75,7 +76,7 @@ const CardContent = ({ filters }: CardContentProps) => {
       `}
     >
       {data?.data?.list
-        ?.filter((attendee: any) => !isMypage || attendee.liked)
+        ?.filter((attendee: any) => isList || attendee.liked)
         .map((attendee: any) => (
           <Box
             key={attendee.attendeeId}
@@ -84,7 +85,7 @@ const CardContent = ({ filters }: CardContentProps) => {
               display: flex;
               min-width: 166px;
               max-width: 288px;
-              border-radius: 18px;
+              border-radius: ${radius.xl};
               padding: 24px;
               flex-direction: column;
               align-items: flex-start;
@@ -114,8 +115,7 @@ const CardContent = ({ filters }: CardContentProps) => {
 
             <Typography
               css={css`
-                font-size: 16px;
-                font-weight: 700;
+                ${typo.title.s}
                 color: ${palette.text.primary};
                 margin-bottom: 4px;
               `}
@@ -124,8 +124,9 @@ const CardContent = ({ filters }: CardContentProps) => {
             </Typography>
             <Typography
               css={css`
+                font-family: ${typo.fontFamily.Pretendard};
                 font-size: 14px;
-                font-weight: 500;
+                font-weight: 700;
                 color: ${palette.text.primary};
                 margin-bottom: 4px;
               `}
@@ -134,10 +135,8 @@ const CardContent = ({ filters }: CardContentProps) => {
             </Typography>
             <Typography
               css={css`
-                font-size: 12px;
+                ${typo.body.s}
                 color: ${palette.text.primary};
-                margin-bottom: 12px;
-                line-height: 1.4;
               `}
             >
               {truncateText(attendee.techStacks, 15)}
@@ -153,7 +152,7 @@ const CardContent = ({ filters }: CardContentProps) => {
             >
               <Typography
                 css={css`
-                  font-size: 12px;
+                  ${typo.body.s}
                   color: ${palette.text.secondary};
                 `}
               >
@@ -170,9 +169,9 @@ const CardContent = ({ filters }: CardContentProps) => {
                 }}
               >
                 {attendee.liked ? (
-                  <FavoriteIcon sx={{ color: '#EB5050', fontSize: 18 }} />
+                  <FavoriteIcon sx={{ color: '#EB5050', fontSize: 24 }} />
                 ) : (
-                  <FavoriteBorderIcon sx={{ color: palette.text.secondary, fontSize: 18 }} />
+                  <FavoriteBorderIcon sx={{ color: palette.text.secondary, fontSize: 24 }} />
                 )}
               </IconButton>
             </Box>

--- a/src/routes/pages/RecruiterMain.tsx
+++ b/src/routes/pages/RecruiterMain.tsx
@@ -1,18 +1,12 @@
 import { Box, Typography, useTheme, css } from '@mui/material';
 import BackHeader from '@components/headers/BackHeader';
-import FavoriteIcon from '@mui/icons-material/Favorite';
+import CardContent from '@components/RecruiterPage/CardContent';
 import { useRecruiterAttendees } from '@stores/server/recruiter';
-import { useNavigate } from 'react-router-dom';
 
 const RecruiterMain = () => {
   const { palette, typo } = useTheme();
-  const { data } = useRecruiterAttendees({});
-  const navigate = useNavigate();
-
-  const likedAttendees = data.data.list.filter((attendee: any) => attendee.liked);
-  const handleCardClick = (attendeeId: number) => {
-    navigate(`/my-info/${attendeeId}`);
-  };
+  const { data: attendeesData } = useRecruiterAttendees({ liked: true });
+  const likedAttendees = attendeesData?.data?.list?.filter((attendee: any) => attendee.liked);
 
   return (
     <>
@@ -30,10 +24,7 @@ const RecruiterMain = () => {
         <Typography
           css={css`
             font-family: ${typo.fontFamily.Pretendard};
-            font-size: 26px;
-            font-style: normal;
-            font-weight: 700;
-            line-height: normal;
+            ${typo.title.l}
             color: ${palette.text.primary};
           `}
         >
@@ -47,95 +38,10 @@ const RecruiterMain = () => {
             gap: 16px;
             margin-top: 20px;
             overflow-y: auto;
+            margin-bottom: 10px;
           `}
         >
-          {likedAttendees.map((attendee: any) => (
-            <Box
-              key={attendee.attendeeId}
-              css={css`
-                background-color: ${palette.background.tertiary};
-                display: flex;
-                min-width: 166px;
-                max-width: 288px;
-                border-radius: 18px;
-                padding: 24px;
-                flex-direction: column;
-                align-items: flex-start;
-                flex: 1 0 0;
-              `}
-              onClick={() => handleCardClick(attendee.attendeeId)}
-            >
-              <Box
-                css={css`
-                  display: flex;
-                  width: 70px;
-                  height: 98px;
-                  flex-direction: column;
-                  justify-content: center;
-                  align-items: center;
-                  aspect-ratio: 5/7
-                  overflow: hidden;
-                  margin-bottom: 10px;
-                `}
-              >
-                <img
-                  src={attendee.profileImageUrl}
-                  alt={`${attendee.name} 프로필 이미지`}
-                  style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-                />
-              </Box>
-
-              <Typography
-                css={css`
-                  font-size: 16px;
-                  font-weight: 700;
-                  color: ${palette.text.primary};
-                  margin-bottom: 4px;
-                `}
-              >
-                {attendee.name}
-              </Typography>
-              <Typography
-                css={css`
-                  font-size: 14px;
-                  font-weight: 500;
-                  color: ${palette.text.primary};
-                  margin-bottom: 4px;
-                `}
-              >
-                {attendee.desiredJobPosition}
-              </Typography>
-              <Typography
-                css={css`
-                  font-size: 12px;
-                  color: ${palette.text.primary};
-                  margin-bottom: 12px;
-                  line-height: 1.4;
-                `}
-              >
-                {attendee.techStacks}
-              </Typography>
-
-              <Box
-                css={css`
-                  width: 100%;
-                  display: flex;
-                  justify-content: space-between;
-                  align-items: center;
-                `}
-              >
-                <Typography
-                  css={css`
-                    font-size: 12px;
-                    color: ${palette.text.secondary};
-                  `}
-                >
-                  {attendee.experienceLevel}
-                </Typography>
-                <FavoriteIcon sx={{ color: '#EB5050', fontSize: 18 }} />
-              </Box>
-            </Box>
-          ))}
+          <CardContent filters={{ liked: true }}/>
         </Box>
       </Box>
     </>

--- a/src/routes/pages/RecruiterMypage.tsx
+++ b/src/routes/pages/RecruiterMypage.tsx
@@ -71,21 +71,39 @@ const RecruiterMypage = () => {
           <Typography
             css={css`
               color: ${palette.text.primary};
-              font-size: 24px;
-              font-weight: 700;
+              ${typo.title.m}
               margin-bottom: 4px;
             `}
           >
             {profileData?.recruiterName} 님, 반갑습니다.
           </Typography>
-          <Typography
+          <Box
             css={css`
-              font-size: 14px;
-              color: ${palette.text.secondary};
+              display: flex;
+              gap: 4px;
+              justify-content: center;
+              align-items: center;
             `}
           >
-            {profileData?.company} {profileData?.responsibility}
-          </Typography>
+            <Typography
+              css={css`
+                ${typo.sub.s}
+                color: ${palette.text.primary};
+                ${typo.fontFamily.Pretendard}
+              `}
+            >
+              {profileData?.company}
+            </Typography>
+            <Typography
+              css={css`
+                ${typo.fontFamily.Pretendard}
+                ${typo.sub.s}
+                color: ${palette.text.secondary};
+              `}
+            >
+              {profileData?.responsibility}
+            </Typography>
+          </Box>
         </Box>
         <Box
           css={css`
@@ -102,15 +120,14 @@ const RecruiterMypage = () => {
         >
           <LogoutOutlinedIcon 
             css={css`
-              width: 16px;
-              height: 16px;
+              width: 18px;
+              height: 18px;
               color: ${palette.icon.tertiary}
               `}
             />
           <Typography
             css={css`
-              font-size: 14px;
-              font-weight: 500;
+              ${typo.sub.s}
               color: ${palette.text.primary};
             `}
           >
@@ -130,14 +147,13 @@ const RecruiterMypage = () => {
             flex-wrap: wrap;
             justify-content: space-between;
             align-items: center;
-            margin-bottom: 16px;
+            margin-bottom: 5px;
             padding: 20px;
           `}
         >
           <Typography
             css={css`
-              font-size: 16px;
-              font-weight: 700;
+              ${typo.sub.s}
               color: ${palette.text.primary};
               font-family: ${typo.fontFamily.Pretendard};
             `}
@@ -153,6 +169,14 @@ const RecruiterMypage = () => {
             onClick={() => navigate('/recruiter/main')}
           />
         </Box>
+        <Box
+          css={css`
+            width: 100%;
+            height: 1px;
+            background-color: ${palette.border.primary};
+            margin-bottom: 16px;
+          `}
+        />
       </Box>
       <Box
         css={css`


### PR DESCRIPTION
## 🚀 반영 브랜치

`hotfix/recruiter` → `main`

<br/>

## ✅ 작업 내용

- 스타일 테마 적용
- RecruiterMain(좋아요한 인재 더보기 페이지): 카드 컴포넌트 호출
- 채용담당자 마이페이지 구분선 추가

<br/>

## 🌠 이미지 첨부


https://github.com/user-attachments/assets/689cd900-2d91-4e3b-8770-f24a9e988202

